### PR TITLE
Headers with capital characters aren't being matched when using a ColumnNameMapper

### DIFF
--- a/src/main/java/org/csveed/row/HeaderImpl.java
+++ b/src/main/java/org/csveed/row/HeaderImpl.java
@@ -21,7 +21,7 @@ public class HeaderImpl implements Header {
         Column currentColumn = new Column();
         for (String headerCell : header) {
             this.indexToName.put(currentColumn, headerCell);
-            this.nameToIndex.put(headerCell, currentColumn);
+            this.nameToIndex.put(headerCell.toLowerCase(), currentColumn);
             currentColumn = currentColumn.nextColumn();
         }
     }

--- a/src/test/java/org/csveed/bean/BeanReaderTest.java
+++ b/src/test/java/org/csveed/bean/BeanReaderTest.java
@@ -199,7 +199,7 @@ public class BeanReaderTest {
     @Test
     public void nameMatching() {
         Reader reader = new StringReader(
-            "street;city;postal code;ignore this\n"+
+            "street;CITY;postal code;ignore this\n"+
             "\"Some street\";\"Some city\";\"Some postal code\";\"Some ignoring\""
         );
         BeanReaderImpl<BeanWithNameMatching> beanReader = new BeanReaderImpl<BeanWithNameMatching>(reader, BeanWithNameMatching.class);

--- a/src/test/java/org/csveed/test/model/BeanWithNameMatching.java
+++ b/src/test/java/org/csveed/test/model/BeanWithNameMatching.java
@@ -13,7 +13,7 @@ public class BeanWithNameMatching {
     @CsvCell(columnName = "street")
     public String line1;
 
-    @CsvCell(columnName = "city")
+    @CsvCell(columnName = "CITY")
     public String line2;
 
     public String getLine1() {


### PR DESCRIPTION
Headers with capital characters aren't being matched when are lowercased but the header names aren't
Changed the nameToIndex map in HeaderImpl to have lowercase keys

Changed an existing test to verify that the changes works
