### PR TITLE
[javadocs] Fill out remainder of javadocs clearing all maven warnings

### DIFF
--- a/src/main/java/org/csveed/api/CsvClientImpl.java
+++ b/src/main/java/org/csveed/api/CsvClientImpl.java
@@ -32,29 +32,63 @@ import org.csveed.row.RowReaderImpl;
 import org.csveed.row.RowWriter;
 import org.csveed.row.RowWriterImpl;
 
+/**
+ * The Class CsvClientImpl.
+ *
+ * @param <T>
+ *            the generic type
+ */
 public class CsvClientImpl<T> implements CsvClient<T> {
 
+    /** The bean reader. */
     private BeanReader<T> beanReader;
 
+    /** The bean writer. */
     private BeanWriter<T> beanWriter;
 
+    /** The row reader. */
     private RowReader rowReader;
 
+    /** The row writer. */
     private RowWriter rowWriter;
 
+    /** The row instructions. */
     private final RowInstructions rowInstructions;
 
+    /** The bean instructions. */
     private BeanInstructions beanInstructions;
 
+    /**
+     * Instantiates a new csv client impl.
+     *
+     * @param writer
+     *            the writer
+     */
     public CsvClientImpl(Writer writer) {
         this.rowWriter = new RowWriterImpl(writer);
         this.rowInstructions = getRowWriter().getRowInstructions();
     }
 
+    /**
+     * Instantiates a new csv client impl.
+     *
+     * @param writer
+     *            the writer
+     * @param beanClass
+     *            the bean class
+     */
     public CsvClientImpl(Writer writer, Class<T> beanClass) {
         this(writer, new BeanParser().getBeanInstructions(beanClass));
     }
 
+    /**
+     * Instantiates a new csv client impl.
+     *
+     * @param writer
+     *            the writer
+     * @param beanInstructions
+     *            the bean instructions
+     */
     public CsvClientImpl(Writer writer, BeanInstructions beanInstructions) {
         this.beanWriter = new BeanWriterImpl<>(writer, beanInstructions);
         this.rowWriter = getBeanWriter().getRowWriter();
@@ -62,15 +96,37 @@ public class CsvClientImpl<T> implements CsvClient<T> {
         this.beanInstructions = beanInstructions;
     }
 
+    /**
+     * Instantiates a new csv client impl.
+     *
+     * @param reader
+     *            the reader
+     */
     public CsvClientImpl(Reader reader) {
         this.rowReader = new RowReaderImpl(reader);
         this.rowInstructions = getRowReader().getRowInstructions();
     }
 
+    /**
+     * Instantiates a new csv client impl.
+     *
+     * @param reader
+     *            the reader
+     * @param beanClass
+     *            the bean class
+     */
     public CsvClientImpl(Reader reader, Class<T> beanClass) {
         this(reader, new BeanParser().getBeanInstructions(beanClass));
     }
 
+    /**
+     * Instantiates a new csv client impl.
+     *
+     * @param reader
+     *            the reader
+     * @param beanInstructions
+     *            the bean instructions
+     */
     public CsvClientImpl(Reader reader, BeanInstructions beanInstructions) {
         this.beanReader = new BeanReaderImpl<>(reader, beanInstructions);
         this.rowReader = getBeanReader().getRowReader();
@@ -278,6 +334,11 @@ public class CsvClientImpl<T> implements CsvClient<T> {
         return this;
     }
 
+    /**
+     * Gets the bean instructions.
+     *
+     * @return the bean instructions
+     */
     private BeanInstructions getBeanInstructions() {
         if (this.beanInstructions == null) {
             throw new CsvException(new GeneralError(
@@ -287,6 +348,11 @@ public class CsvClientImpl<T> implements CsvClient<T> {
         return this.beanInstructions;
     }
 
+    /**
+     * Gets the bean reader.
+     *
+     * @return the bean reader
+     */
     private BeanReader<T> getBeanReader() {
         if (this.beanReader == null) {
             throw new CsvException(new GeneralError(
@@ -295,6 +361,11 @@ public class CsvClientImpl<T> implements CsvClient<T> {
         return this.beanReader;
     }
 
+    /**
+     * Gets the bean writer.
+     *
+     * @return the bean writer
+     */
     private BeanWriter<T> getBeanWriter() {
         if (this.beanWriter == null) {
             throw new CsvException(new GeneralError(
@@ -303,6 +374,11 @@ public class CsvClientImpl<T> implements CsvClient<T> {
         return this.beanWriter;
     }
 
+    /**
+     * Gets the row reader.
+     *
+     * @return the row reader
+     */
     private RowReader getRowReader() {
         if (this.rowReader == null) {
             throw new CsvException(new GeneralError(
@@ -311,6 +387,11 @@ public class CsvClientImpl<T> implements CsvClient<T> {
         return this.rowReader;
     }
 
+    /**
+     * Gets the row writer.
+     *
+     * @return the row writer
+     */
     public RowWriter getRowWriter() {
         if (this.rowWriter == null) {
             throw new CsvException(new GeneralError(

--- a/src/main/java/org/csveed/bean/AbstractMapper.java
+++ b/src/main/java/org/csveed/bean/AbstractMapper.java
@@ -21,20 +21,56 @@ import org.csveed.common.Column;
 import org.csveed.report.CsvException;
 import org.csveed.report.RowError;
 
+/**
+ * The Class AbstractMapper.
+ *
+ * @param <T>
+ *            the generic type
+ */
 public abstract class AbstractMapper<T> {
 
+    /** The bean instructions. */
     protected BeanInstructions beanInstructions;
 
+    /** The verified. */
     private boolean verified;
 
+    /** The default converters. */
     private DefaultConverters defaultConverters = new DefaultConverters();
 
+    /**
+     * Gets the bean property.
+     *
+     * @param currentColumn
+     *            the current column
+     *
+     * @return the bean property
+     */
     public abstract BeanProperty getBeanProperty(Column currentColumn);
 
+    /**
+     * Keys.
+     *
+     * @return the sets the
+     */
     protected abstract Set<Column> keys();
 
+    /**
+     * Check key.
+     *
+     * @param header
+     *            the header
+     * @param key
+     *            the key
+     */
     protected abstract void checkKey(Header header, Column key);
 
+    /**
+     * Verify header.
+     *
+     * @param header
+     *            the header
+     */
     public void verifyHeader(Header header) {
         if (verified) {
             return;
@@ -47,8 +83,30 @@ public abstract class AbstractMapper<T> {
         verified = true;
     }
 
+    /**
+     * Gets the column.
+     *
+     * @param row
+     *            the row
+     *
+     * @return the column
+     */
     protected abstract Column getColumn(Row row);
 
+    /**
+     * Convert.
+     *
+     * @param bean
+     *            the bean
+     * @param row
+     *            the row
+     * @param lineNumber
+     *            the line number
+     * @param currentDynamicColumn
+     *            the current dynamic column
+     *
+     * @return the t
+     */
     public T convert(T bean, Row row, int lineNumber, DynamicColumn currentDynamicColumn) {
         BeanWrapper beanWrapper = new BeanWrapper(defaultConverters, bean);
 
@@ -76,6 +134,18 @@ public abstract class AbstractMapper<T> {
         return bean;
     }
 
+    /**
+     * Sets the dynamic column properties.
+     *
+     * @param row
+     *            the row
+     * @param lineNumber
+     *            the line number
+     * @param beanWrapper
+     *            the bean wrapper
+     * @param currentColumn
+     *            the current column
+     */
     private void setDynamicColumnProperties(Row row, int lineNumber, BeanWrapper beanWrapper, Column currentColumn) {
         BeanProperty headerNameProperty = beanInstructions.getProperties().getHeaderNameProperty();
         if (headerNameProperty != null) {
@@ -90,6 +160,22 @@ public abstract class AbstractMapper<T> {
         }
     }
 
+    /**
+     * Sets the bean property.
+     *
+     * @param row
+     *            the row
+     * @param lineNumber
+     *            the line number
+     * @param beanWrapper
+     *            the bean wrapper
+     * @param currentColumn
+     *            the current column
+     * @param cell
+     *            the cell
+     * @param beanProperty
+     *            the bean property
+     */
     private void setBeanProperty(Row row, int lineNumber, BeanWrapper beanWrapper, Column currentColumn, String cell,
             BeanProperty beanProperty) {
         try {
@@ -102,6 +188,12 @@ public abstract class AbstractMapper<T> {
         }
     }
 
+    /**
+     * Sets the bean instructions.
+     *
+     * @param beanInstructions
+     *            the new bean instructions
+     */
     public void setBeanInstructions(BeanInstructions beanInstructions) {
         this.beanInstructions = beanInstructions;
     }

--- a/src/main/java/org/csveed/bean/BeanInstructionsImpl.java
+++ b/src/main/java/org/csveed/bean/BeanInstructionsImpl.java
@@ -21,24 +21,41 @@ import org.csveed.row.RowInstructionsImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The Class BeanInstructionsImpl.
+ */
 public class BeanInstructionsImpl implements BeanInstructions {
 
+    /** The Constant LOG. */
     private static final Logger LOG = LoggerFactory.getLogger(BeanInstructionsImpl.class);
 
+    /** The row instructions. */
     private RowInstructions rowInstructions = new RowInstructionsImpl();
 
+    /** The properties. */
     private BeanProperties properties;
 
+    /** The mapping strategy. */
     private Class<? extends AbstractMapper> mappingStrategy = ColumnIndexMapper.class;
 
+    /** The bean class. */
     private Class beanClass;
 
+    /** The settings logged. */
     private boolean settingsLogged;
 
+    /** The start index dynamic columns. */
     private Column startIndexDynamicColumns;
 
+    /** The use header. */
     private boolean useHeader = true;
 
+    /**
+     * Instantiates a new bean instructions impl.
+     *
+     * @param beanClass
+     *            the bean class
+     */
     public BeanInstructionsImpl(Class beanClass) {
         this.properties = new BeanProperties(beanClass);
         this.beanClass = beanClass;
@@ -56,6 +73,14 @@ public class BeanInstructionsImpl implements BeanInstructions {
         settingsLogged = true;
     }
 
+    /**
+     * Gets the property log line.
+     *
+     * @param property
+     *            the property
+     *
+     * @return the property log line
+     */
     protected String getPropertyLogLine(BeanProperty property) {
         List<String> lineParts = new ArrayList<>();
         lineParts.add("- CSV config");

--- a/src/main/java/org/csveed/bean/BeanParser.java
+++ b/src/main/java/org/csveed/bean/BeanParser.java
@@ -24,12 +24,25 @@ import org.csveed.annotations.CsvIgnore;
 import org.csveed.annotations.CsvLocalizedNumber;
 import org.csveed.common.Column;
 
+/**
+ * The Class BeanParser.
+ */
 public class BeanParser {
 
+    /** The bean instructions. */
     private BeanInstructions beanInstructions;
 
+    /** The current column. */
     private Column currentColumn = new Column();
 
+    /**
+     * Gets the bean instructions.
+     *
+     * @param beanClass
+     *            the bean class
+     *
+     * @return the bean instructions
+     */
     public BeanInstructions getBeanInstructions(Class beanClass) {
 
         this.beanInstructions = new BeanInstructionsImpl(beanClass);
@@ -48,6 +61,12 @@ public class BeanParser {
         return this.beanInstructions;
     }
 
+    /**
+     * Check for annotations.
+     *
+     * @param beanProperty
+     *            the bean property
+     */
     public void checkForAnnotations(BeanProperty beanProperty) {
 
         Field currentField = beanProperty.getField();
@@ -77,6 +96,14 @@ public class BeanParser {
         currentColumn = currentColumn.nextColumn();
     }
 
+    /**
+     * Parses the csv localized number.
+     *
+     * @param propertyName
+     *            the property name
+     * @param annotation
+     *            the annotation
+     */
     private void parseCsvLocalizedNumber(String propertyName, CsvLocalizedNumber annotation) {
         final Locale locale;
         if (annotation.country().isEmpty()) {
@@ -89,6 +116,12 @@ public class BeanParser {
         this.beanInstructions.setLocalizedNumber(propertyName, locale);
     }
 
+    /**
+     * Parses the csv file.
+     *
+     * @param csvFile
+     *            the csv file
+     */
     private void parseCsvFile(CsvFile csvFile) {
 
         this.beanInstructions.setEscape(csvFile.escape()).setQuote(csvFile.quote())
@@ -99,10 +132,26 @@ public class BeanParser {
                 .setStartIndexDynamicColumns(csvFile.startIndexDynamicColumns());
     }
 
+    /**
+     * Parses the csv date.
+     *
+     * @param propertyName
+     *            the property name
+     * @param csvDate
+     *            the csv date
+     */
     private void parseCsvDate(String propertyName, CsvDate csvDate) {
         this.beanInstructions.setDate(propertyName, csvDate.format());
     }
 
+    /**
+     * Parses the csv converter.
+     *
+     * @param propertyName
+     *            the property name
+     * @param csvConverter
+     *            the csv converter
+     */
     private void parseCsvConverter(String propertyName, CsvConverter csvConverter) {
         try {
             this.beanInstructions.setConverter(propertyName,
@@ -112,6 +161,16 @@ public class BeanParser {
         }
     }
 
+    /**
+     * Parses the csv cell.
+     *
+     * @param propertyName
+     *            the property name
+     * @param csvCell
+     *            the csv cell
+     *
+     * @return the string
+     */
     private String parseCsvCell(String propertyName, CsvCell csvCell) {
         String columnName = csvCell.columnName() == null || csvCell.columnName().isEmpty() ? propertyName
                 : csvCell.columnName();

--- a/src/main/java/org/csveed/bean/BeanProperties.java
+++ b/src/main/java/org/csveed/bean/BeanProperties.java
@@ -34,25 +34,49 @@ import org.csveed.report.GeneralError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The Class BeanProperties.
+ */
 public class BeanProperties implements Iterable<BeanProperty> {
 
+    /** The Constant LOG. */
     private static final Logger LOG = LoggerFactory.getLogger(BeanProperties.class);
 
+    /** The properties. */
     private List<BeanProperty> properties = new ArrayList<>();
 
+    /** The index to property. */
     private Map<Column, BeanProperty> indexToProperty = new TreeMap<>();
+
+    /** The name to property. */
     private Map<Column, BeanProperty> nameToProperty = new TreeMap<>();
 
+    /** The bean class. */
     private Class beanClass;
 
+    /** The header value property. */
     private BeanProperty headerValueProperty;
+
+    /** The header name property. */
     private BeanProperty headerNameProperty;
 
+    /**
+     * Instantiates a new bean properties.
+     *
+     * @param beanClass
+     *            the bean class
+     */
     public BeanProperties(Class beanClass) {
         this.beanClass = beanClass;
         parseBean(beanClass);
     }
 
+    /**
+     * Parses the bean.
+     *
+     * @param beanClass
+     *            the bean class
+     */
     private void parseBean(Class beanClass) {
         final BeanInfo beanInfo;
         try {
@@ -79,6 +103,14 @@ public class BeanProperties implements Iterable<BeanProperty> {
         }
     }
 
+    /**
+     * Adds the property.
+     *
+     * @param propertyDescriptor
+     *            the property descriptor
+     * @param field
+     *            the field
+     */
     @SuppressWarnings("unchecked")
     private void addProperty(PropertyDescriptor propertyDescriptor, Field field) {
         BeanProperty beanProperty = new BeanProperty();
@@ -90,6 +122,16 @@ public class BeanProperties implements Iterable<BeanProperty> {
         this.properties.add(beanProperty);
     }
 
+    /**
+     * Gets the property descriptor.
+     *
+     * @param propertyDescriptors
+     *            the property descriptors
+     * @param field
+     *            the field
+     *
+     * @return the property descriptor
+     */
     private PropertyDescriptor getPropertyDescriptor(PropertyDescriptor[] propertyDescriptors, Field field) {
         for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
             if (field.getName().equals(propertyDescriptor.getName())) {
@@ -99,14 +141,38 @@ public class BeanProperties implements Iterable<BeanProperty> {
         return null;
     }
 
+    /**
+     * Sets the required.
+     *
+     * @param propertyName
+     *            the property name
+     * @param required
+     *            the required
+     */
     public void setRequired(String propertyName, boolean required) {
         get(propertyName).setRequired(required);
     }
 
+    /**
+     * Sets the date.
+     *
+     * @param propertyName
+     *            the property name
+     * @param formatText
+     *            the format text
+     */
     public void setDate(String propertyName, String formatText) {
         setConverter(propertyName, new DateConverter(formatText, true));
     }
 
+    /**
+     * Sets the localized number.
+     *
+     * @param propertyName
+     *            the property name
+     * @param locale
+     *            the locale
+     */
     public void setLocalizedNumber(String propertyName, Locale locale) {
         Class<? extends Number> numberClass = get(propertyName).getNumberClass();
         if (numberClass == null) {
@@ -118,22 +184,48 @@ public class BeanProperties implements Iterable<BeanProperty> {
         setConverter(propertyName, converter);
     }
 
+    /**
+     * Sets the converter.
+     *
+     * @param propertyName
+     *            the property name
+     * @param converter
+     *            the converter
+     */
     public void setConverter(String propertyName, Converter converter) {
         get(propertyName).setConverter(converter);
     }
 
+    /**
+     * Removes the from column index.
+     *
+     * @param property
+     *            the property
+     */
     protected void removeFromColumnIndex(BeanProperty property) {
         while (indexToProperty.values().remove(property)) {
 
         }
     }
 
+    /**
+     * Removes the from column name.
+     *
+     * @param property
+     *            the property
+     */
     protected void removeFromColumnName(BeanProperty property) {
         while (nameToProperty.values().remove(property)) {
 
         }
     }
 
+    /**
+     * Ignore property.
+     *
+     * @param propertyName
+     *            the property name
+     */
     public void ignoreProperty(String propertyName) {
         BeanProperty property = get(propertyName);
         properties.remove(property);
@@ -141,24 +233,54 @@ public class BeanProperties implements Iterable<BeanProperty> {
         removeFromColumnName(property);
     }
 
+    /**
+     * Sets the header value property.
+     *
+     * @param propertyName
+     *            the new header value property
+     */
     public void setHeaderValueProperty(String propertyName) {
         this.headerValueProperty = get(propertyName);
         this.headerValueProperty.setDynamicColumnProperty(true);
     }
 
+    /**
+     * Sets the header name property.
+     *
+     * @param propertyName
+     *            the new header name property
+     */
     public void setHeaderNameProperty(String propertyName) {
         this.headerNameProperty = get(propertyName);
         this.headerNameProperty.setDynamicColumnProperty(true);
     }
 
+    /**
+     * Gets the header value property.
+     *
+     * @return the header value property
+     */
     public BeanProperty getHeaderValueProperty() {
         return this.headerValueProperty;
     }
 
+    /**
+     * Gets the header name property.
+     *
+     * @return the header name property
+     */
     public BeanProperty getHeaderNameProperty() {
         return this.headerNameProperty;
     }
 
+    /**
+     * Map index to property.
+     *
+     * @param columnIndex
+     *            the column index
+     * @param propertyName
+     *            the property name
+     */
     public void mapIndexToProperty(int columnIndex, String propertyName) {
         BeanProperty property = get(propertyName);
         removeFromColumnIndex(property);
@@ -166,6 +288,14 @@ public class BeanProperties implements Iterable<BeanProperty> {
         indexToProperty.put(new Column(columnIndex), property);
     }
 
+    /**
+     * Map name to property.
+     *
+     * @param columnName
+     *            the column name
+     * @param propertyName
+     *            the property name
+     */
     public void mapNameToProperty(String columnName, String propertyName) {
         BeanProperty property = get(propertyName);
         removeFromColumnName(property);
@@ -173,6 +303,14 @@ public class BeanProperties implements Iterable<BeanProperty> {
         nameToProperty.put(new Column(columnName.toLowerCase(Locale.getDefault())), property);
     }
 
+    /**
+     * Gets the.
+     *
+     * @param propertyName
+     *            the property name
+     *
+     * @return the bean property
+     */
     protected BeanProperty get(String propertyName) {
         for (BeanProperty beanProperty : properties) {
             if (beanProperty.getPropertyName().equals(propertyName)) {
@@ -183,10 +321,26 @@ public class BeanProperties implements Iterable<BeanProperty> {
                 new GeneralError("Property does not exist: " + beanClass.getName() + "." + propertyName));
     }
 
+    /**
+     * From index.
+     *
+     * @param column
+     *            the column
+     *
+     * @return the bean property
+     */
     public BeanProperty fromIndex(Column column) {
         return indexToProperty.get(column);
     }
 
+    /**
+     * From name.
+     *
+     * @param column
+     *            the column
+     *
+     * @return the bean property
+     */
     public BeanProperty fromName(Column column) {
         return nameToProperty.get(column);
     }
@@ -197,10 +351,20 @@ public class BeanProperties implements Iterable<BeanProperty> {
         return ((List<BeanProperty>) ((ArrayList<BeanProperty>) this.properties).clone()).iterator();
     }
 
+    /**
+     * Column index keys.
+     *
+     * @return the sets the
+     */
     public Set<Column> columnIndexKeys() {
         return this.indexToProperty.keySet();
     }
 
+    /**
+     * Column name keys.
+     *
+     * @return the sets the
+     */
     public Set<Column> columnNameKeys() {
         return this.nameToProperty.keySet();
     }

--- a/src/main/java/org/csveed/bean/BeanProperty.java
+++ b/src/main/java/org/csveed/bean/BeanProperty.java
@@ -15,22 +15,37 @@ import java.lang.reflect.Field;
 
 import org.csveed.bean.conversion.Converter;
 
+/**
+ * The Class BeanProperty.
+ */
 public class BeanProperty {
 
+    /** The property descriptor. */
     private PropertyDescriptor propertyDescriptor;
 
+    /** The field. */
     private Field field;
 
+    /** The converter. */
     private Converter converter;
 
+    /** The column name. */
     private String columnName;
 
+    /** The column index. */
     private int columnIndex = -1;
 
+    /** The required. */
     private boolean required;
 
+    /** The dynamic column property. */
     private boolean dynamicColumnProperty;
 
+    /**
+     * Gets the number class.
+     *
+     * @return the number class
+     */
     @SuppressWarnings("unchecked")
     public Class<? extends Number> getNumberClass() {
         if (Number.class.isAssignableFrom(propertyDescriptor.getPropertyType())) {
@@ -39,62 +54,144 @@ public class BeanProperty {
         return null;
     }
 
+    /**
+     * Gets the property descriptor.
+     *
+     * @return the property descriptor
+     */
     public PropertyDescriptor getPropertyDescriptor() {
         return propertyDescriptor;
     }
 
+    /**
+     * Sets the property descriptor.
+     *
+     * @param propertyDescriptor
+     *            the new property descriptor
+     */
     public void setPropertyDescriptor(PropertyDescriptor propertyDescriptor) {
         this.propertyDescriptor = propertyDescriptor;
     }
 
+    /**
+     * Gets the converter.
+     *
+     * @return the converter
+     */
     public Converter getConverter() {
         return converter;
     }
 
+    /**
+     * Sets the converter.
+     *
+     * @param converter
+     *            the new converter
+     */
     public void setConverter(Converter converter) {
         this.converter = converter;
     }
 
+    /**
+     * Gets the column name.
+     *
+     * @return the column name
+     */
     public String getColumnName() {
         return columnName;
     }
 
+    /**
+     * Sets the column name.
+     *
+     * @param columnName
+     *            the new column name
+     */
     public void setColumnName(String columnName) {
         this.columnName = columnName;
     }
 
+    /**
+     * Checks if is required.
+     *
+     * @return true, if is required
+     */
     public boolean isRequired() {
         return required;
     }
 
+    /**
+     * Sets the required.
+     *
+     * @param required
+     *            the new required
+     */
     public void setRequired(boolean required) {
         this.required = required;
     }
 
+    /**
+     * Gets the column index.
+     *
+     * @return the column index
+     */
     public int getColumnIndex() {
         return columnIndex;
     }
 
+    /**
+     * Sets the column index.
+     *
+     * @param columnIndex
+     *            the new column index
+     */
     public void setColumnIndex(int columnIndex) {
         this.columnIndex = columnIndex;
     }
 
+    /**
+     * Gets the field.
+     *
+     * @return the field
+     */
     public Field getField() {
         return field;
     }
 
+    /**
+     * Sets the field.
+     *
+     * @param field
+     *            the new field
+     */
     public void setField(Field field) {
         this.field = field;
     }
 
+    /**
+     * Gets the property name.
+     *
+     * @return the property name
+     */
     public String getPropertyName() {
         return propertyDescriptor.getName();
     }
 
+    /**
+     * Sets the dynamic column property.
+     *
+     * @param dynamicColumnProperty
+     *            the new dynamic column property
+     */
     public void setDynamicColumnProperty(boolean dynamicColumnProperty) {
         this.dynamicColumnProperty = dynamicColumnProperty;
     }
 
+    /**
+     * Checks if is dynamic column property.
+     *
+     * @return true, if is dynamic column property
+     */
     public boolean isDynamicColumnProperty() {
         return this.dynamicColumnProperty;
     }
@@ -113,6 +210,11 @@ public class BeanProperty {
         return getPropertyName().equals(other.getPropertyName());
     }
 
+    /**
+     * Gets the property type.
+     *
+     * @return the property type
+     */
     public String getPropertyType() {
         return getConverter() != null ? getConverter().infoOnType()
                 : getPropertyDescriptor().getPropertyType().getName();

--- a/src/main/java/org/csveed/bean/BeanReaderImpl.java
+++ b/src/main/java/org/csveed/bean/BeanReaderImpl.java
@@ -23,30 +23,63 @@ import org.csveed.row.RowReaderImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The Class BeanReaderImpl.
+ *
+ * @param <T>
+ *            the generic type
+ */
 public class BeanReaderImpl<T> implements BeanReader<T> {
 
+    /** The Constant logger. */
     private static final Logger logger = LoggerFactory.getLogger(BeanReaderImpl.class);
 
+    /** The row reader. */
     private final RowReader rowReader;
 
+    /** The bean instructions. */
     private final BeanInstructions beanInstructions;
 
+    /** The mapper. */
     private AbstractMapper<T> mapper;
 
+    /** The current dynamic column. */
     private final DynamicColumn currentDynamicColumn;
 
+    /** The unmapped row. */
     private Row unmappedRow;
 
+    /**
+     * Instantiates a new bean reader impl.
+     *
+     * @param reader
+     *            the reader
+     * @param beanClass
+     *            the bean class
+     */
     public BeanReaderImpl(Reader reader, Class<T> beanClass) {
         this(reader, new BeanParser().getBeanInstructions(beanClass));
     }
 
+    /**
+     * Instantiates a new bean reader impl.
+     *
+     * @param reader
+     *            the reader
+     * @param beanInstructions
+     *            the bean instructions
+     */
     public BeanReaderImpl(Reader reader, BeanInstructions beanInstructions) {
         this.beanInstructions = beanInstructions;
         this.rowReader = new RowReaderImpl(reader, this.beanInstructions.getRowInstructions());
         this.currentDynamicColumn = new DynamicColumn(this.beanInstructions.getStartIndexDynamicColumns());
     }
 
+    /**
+     * Gets the mapper.
+     *
+     * @return the mapper
+     */
     public AbstractMapper<T> getMapper() {
         if (this.mapper == null) {
             this.mapper = this.createMappingStrategy();
@@ -88,10 +121,18 @@ public class BeanReaderImpl<T> implements BeanReader<T> {
         return bean;
     }
 
+    /**
+     * Log settings.
+     */
     protected void logSettings() {
         this.beanInstructions.logSettings();
     }
 
+    /**
+     * Gets the header.
+     *
+     * @return the header
+     */
     protected Header getHeader() {
         if (this.beanInstructions.useHeader()) {
             return rowReader.getHeader();
@@ -119,6 +160,11 @@ public class BeanReaderImpl<T> implements BeanReader<T> {
         return this.rowReader;
     }
 
+    /**
+     * Instantiate bean.
+     *
+     * @return the t
+     */
     private T instantiateBean() {
         try {
             return this.getBeanClass().getDeclaredConstructor().newInstance();
@@ -128,11 +174,21 @@ public class BeanReaderImpl<T> implements BeanReader<T> {
         }
     }
 
+    /**
+     * Gets the bean class.
+     *
+     * @return the bean class
+     */
     @SuppressWarnings("unchecked")
     public Class<T> getBeanClass() {
         return this.beanInstructions.getBeanClass();
     }
 
+    /**
+     * Creates the mapping strategy.
+     *
+     * @return the abstract mapper
+     */
     @SuppressWarnings("unchecked")
     public AbstractMapper<T> createMappingStrategy() {
         try {

--- a/src/main/java/org/csveed/bean/BeanWriter.java
+++ b/src/main/java/org/csveed/bean/BeanWriter.java
@@ -43,6 +43,11 @@ public interface BeanWriter<T> {
      */
     void writeHeader();
 
+    /**
+     * Gets the row writer.
+     *
+     * @return the row writer
+     */
     RowWriter getRowWriter();
 
 }

--- a/src/main/java/org/csveed/bean/BeanWriterImpl.java
+++ b/src/main/java/org/csveed/bean/BeanWriterImpl.java
@@ -24,24 +24,52 @@ import org.csveed.row.RowWriterImpl;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The Class BeanWriterImpl.
+ *
+ * @param <T>
+ *            the generic type
+ */
 public class BeanWriterImpl<T> implements BeanWriter<T> {
 
+    /** The Constant logger. */
     private static final Logger logger = LoggerFactory.getLogger(BeanWriterImpl.class);
 
+    /** The row writer. */
     private final RowWriter rowWriter;
 
+    /** The bean instructions. */
     private final BeanInstructions beanInstructions;
 
+    /** The header written. */
     private boolean headerWritten;
 
+    /** The default converters. */
     private DefaultConverters defaultConverters = new DefaultConverters();
 
+    /** The header. */
     private HeaderImpl header;
 
+    /**
+     * Instantiates a new bean writer impl.
+     *
+     * @param writer
+     *            the writer
+     * @param beanClass
+     *            the bean class
+     */
     public BeanWriterImpl(Writer writer, Class<T> beanClass) {
         this(writer, new BeanParser().getBeanInstructions(beanClass));
     }
 
+    /**
+     * Instantiates a new bean writer impl.
+     *
+     * @param writer
+     *            the writer
+     * @param beanInstructions
+     *            the bean instructions
+     */
     public BeanWriterImpl(Writer writer, BeanInstructions beanInstructions) {
         this.beanInstructions = beanInstructions;
         this.rowWriter = new RowWriterImpl(writer, this.beanInstructions.getRowInstructions());

--- a/src/main/java/org/csveed/bean/ColumnIndexMapper.java
+++ b/src/main/java/org/csveed/bean/ColumnIndexMapper.java
@@ -18,6 +18,12 @@ import org.csveed.common.Column;
 import org.csveed.report.CsvException;
 import org.csveed.report.GeneralError;
 
+/**
+ * The Class ColumnIndexMapper.
+ *
+ * @param <T>
+ *            the generic type
+ */
 public class ColumnIndexMapper<T> extends AbstractMapper<T> {
 
     @Override

--- a/src/main/java/org/csveed/bean/ColumnNameMapper.java
+++ b/src/main/java/org/csveed/bean/ColumnNameMapper.java
@@ -20,8 +20,15 @@ import org.csveed.report.RowError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The Class ColumnNameMapper.
+ *
+ * @param <T>
+ *            the generic type
+ */
 public class ColumnNameMapper<T> extends AbstractMapper<T> {
 
+    /** The Constant logger. */
     private static final Logger logger = LoggerFactory.getLogger(ColumnNameMapper.class);
 
     @Override

--- a/src/main/java/org/csveed/bean/DynamicColumn.java
+++ b/src/main/java/org/csveed/bean/DynamicColumn.java
@@ -54,33 +54,66 @@ import org.csveed.common.Column;
  */
 public class DynamicColumn {
 
+    /** The start column. */
     private Column startColumn;
 
+    /** The current column. */
     private Column currentColumn;
 
+    /**
+     * Instantiates a new dynamic column.
+     *
+     * @param configuredStartColumn
+     *            the configured start column
+     */
     public DynamicColumn(Column configuredStartColumn) {
         this.startColumn = configuredStartColumn == null ? null : new Column(configuredStartColumn);
         this.currentColumn = configuredStartColumn == null ? null : new Column(configuredStartColumn);
     }
 
+    /**
+     * Check for reset.
+     *
+     * @param numberOfColumns
+     *            the number of columns
+     */
     public void checkForReset(int numberOfColumns) {
         if (lastDynamicColumnPassed(numberOfColumns)) {
             reset();
         }
     }
 
+    /**
+     * Reset.
+     */
     protected void reset() {
         this.currentColumn = new Column(this.startColumn);
     }
 
+    /**
+     * Last dynamic column passed.
+     *
+     * @param numberOfColumns
+     *            the number of columns
+     *
+     * @return true, if successful
+     */
     protected boolean lastDynamicColumnPassed(int numberOfColumns) {
         return this.currentColumn != null && this.currentColumn.getColumnIndex() > numberOfColumns;
     }
 
+    /**
+     * At first dynamic column.
+     *
+     * @return true, if successful
+     */
     public boolean atFirstDynamicColumn() {
         return this.startColumn == null || this.startColumn.equals(this.currentColumn);
     }
 
+    /**
+     * Advance dynamic column.
+     */
     public void advanceDynamicColumn() {
         if (currentColumn == null) {
             return;
@@ -88,6 +121,14 @@ public class DynamicColumn {
         this.currentColumn = currentColumn.nextColumn();
     }
 
+    /**
+     * Checks if is dynamic column active.
+     *
+     * @param currentColumn
+     *            the current column
+     *
+     * @return true, if is dynamic column active
+     */
     public boolean isDynamicColumnActive(Column currentColumn) {
         return this.currentColumn != null && this.currentColumn.getColumnIndex() == currentColumn.getColumnIndex();
     }

--- a/src/main/java/org/csveed/bean/conversion/AbstractConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/AbstractConverter.java
@@ -10,10 +10,23 @@
  */
 package org.csveed.bean.conversion;
 
+/**
+ * The Class AbstractConverter.
+ *
+ * @param <K>
+ *            the key type
+ */
 public abstract class AbstractConverter<K> implements Converter<K> {
 
+    /** The clazz. */
     private Class<K> clazz;
 
+    /**
+     * Instantiates a new abstract converter.
+     *
+     * @param clazz
+     *            the clazz
+     */
     protected AbstractConverter(Class<K> clazz) {
         this.clazz = clazz;
     }

--- a/src/main/java/org/csveed/bean/conversion/BeanPropertyConversionException.java
+++ b/src/main/java/org/csveed/bean/conversion/BeanPropertyConversionException.java
@@ -10,10 +10,24 @@
  */
 package org.csveed.bean.conversion;
 
+/**
+ * The Class BeanPropertyConversionException.
+ */
 public class BeanPropertyConversionException extends ConversionException {
 
+    /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new bean property conversion exception.
+     *
+     * @param message
+     *            the message
+     * @param propertyDescription
+     *            the property description
+     * @param exception
+     *            the exception
+     */
     public BeanPropertyConversionException(String message, String propertyDescription, Throwable exception) {
         super(message, propertyDescription, exception);
     }

--- a/src/main/java/org/csveed/bean/conversion/BeanWrapper.java
+++ b/src/main/java/org/csveed/bean/conversion/BeanWrapper.java
@@ -14,17 +14,41 @@ import java.lang.reflect.Method;
 
 import org.csveed.bean.BeanProperty;
 
+/**
+ * The Class BeanWrapper.
+ */
 public class BeanWrapper {
 
+    /** The default converters. */
     private DefaultConverters defaultConverters;
 
+    /** The bean. */
     private Object bean;
 
+    /**
+     * Instantiates a new bean wrapper.
+     *
+     * @param defaultConverters
+     *            the default converters
+     * @param bean
+     *            the bean
+     */
     public BeanWrapper(DefaultConverters defaultConverters, Object bean) {
         this.defaultConverters = defaultConverters;
         this.bean = bean;
     }
 
+    /**
+     * Gets the property.
+     *
+     * @param property
+     *            the property
+     *
+     * @return the property
+     *
+     * @throws ConversionException
+     *             the conversion exception
+     */
     public String getProperty(BeanProperty property) throws ConversionException {
         Method readMethod = property.getPropertyDescriptor().getReadMethod();
         Converter converter = getConverter(property);
@@ -39,6 +63,17 @@ public class BeanWrapper {
         }
     }
 
+    /**
+     * Sets the property.
+     *
+     * @param property
+     *            the property
+     * @param value
+     *            the value
+     *
+     * @throws ConversionException
+     *             the conversion exception
+     */
     public void setProperty(BeanProperty property, String value) throws ConversionException {
         Method writeMethod = property.getPropertyDescriptor().getWriteMethod();
         Converter converter = getConverter(property);
@@ -52,6 +87,14 @@ public class BeanWrapper {
         }
     }
 
+    /**
+     * Gets the converter.
+     *
+     * @param property
+     *            the property
+     *
+     * @return the converter
+     */
     protected Converter getConverter(BeanProperty property) {
         if (property.getConverter() != null) {
             return property.getConverter();
@@ -59,6 +102,14 @@ public class BeanWrapper {
         return defaultConverters.getConverter(getPropertyType(property));
     }
 
+    /**
+     * Gets the property type.
+     *
+     * @param property
+     *            the property
+     *
+     * @return the property type
+     */
     protected Class getPropertyType(BeanProperty property) {
         return property.getPropertyDescriptor().getPropertyType();
     }

--- a/src/main/java/org/csveed/bean/conversion/ByteArrayConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/ByteArrayConverter.java
@@ -12,8 +12,14 @@ package org.csveed.bean.conversion;
 
 import java.nio.charset.Charset;
 
+/**
+ * The Class ByteArrayConverter.
+ */
 public class ByteArrayConverter extends AbstractConverter<byte[]> {
 
+    /**
+     * Instantiates a new byte array converter.
+     */
     public ByteArrayConverter() {
         super(byte[].class);
     }

--- a/src/main/java/org/csveed/bean/conversion/CharArrayConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/CharArrayConverter.java
@@ -10,8 +10,14 @@
  */
 package org.csveed.bean.conversion;
 
+/**
+ * The Class CharArrayConverter.
+ */
 public class CharArrayConverter extends AbstractConverter<char[]> {
 
+    /**
+     * Instantiates a new char array converter.
+     */
     public CharArrayConverter() {
         super(char[].class);
     }

--- a/src/main/java/org/csveed/bean/conversion/CharacterConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/CharacterConverter.java
@@ -12,14 +12,26 @@ package org.csveed.bean.conversion;
 
 import static org.csveed.bean.conversion.ConversionUtil.hasLength;
 
+/**
+ * The Class CharacterConverter.
+ */
 public class CharacterConverter extends AbstractConverter<Character> {
 
+    /** The Constant UNICODE_PREFIX. */
     private static final String UNICODE_PREFIX = "\\u";
 
+    /** The Constant UNICODE_LENGTH. */
     private static final int UNICODE_LENGTH = 6;
 
+    /** The allow empty. */
     private final boolean allowEmpty;
 
+    /**
+     * Instantiates a new character converter.
+     *
+     * @param allowEmpty
+     *            the allow empty
+     */
     public CharacterConverter(boolean allowEmpty) {
         super(Character.class);
         this.allowEmpty = allowEmpty;
@@ -49,6 +61,14 @@ public class CharacterConverter extends AbstractConverter<Character> {
         return value != null ? value.toString() : "";
     }
 
+    /**
+     * Checks if is unicode character sequence.
+     *
+     * @param sequence
+     *            the sequence
+     *
+     * @return true, if is unicode character sequence
+     */
     private boolean isUnicodeCharacterSequence(String sequence) {
         return sequence.startsWith(UNICODE_PREFIX) && sequence.length() == UNICODE_LENGTH;
     }

--- a/src/main/java/org/csveed/bean/conversion/CharsetConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/CharsetConverter.java
@@ -12,8 +12,14 @@ package org.csveed.bean.conversion;
 
 import java.nio.charset.Charset;
 
+/**
+ * The Class CharsetConverter.
+ */
 public class CharsetConverter extends AbstractConverter<Charset> {
 
+    /**
+     * Instantiates a new charset converter.
+     */
     public CharsetConverter() {
         super(Charset.class);
     }

--- a/src/main/java/org/csveed/bean/conversion/ConversionException.java
+++ b/src/main/java/org/csveed/bean/conversion/ConversionException.java
@@ -10,21 +10,49 @@
  */
 package org.csveed.bean.conversion;
 
+/**
+ * The Class ConversionException.
+ */
 public abstract class ConversionException extends Exception {
 
+    /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /** The type description. */
     private String typeDescription;
 
+    /**
+     * Instantiates a new conversion exception.
+     *
+     * @param message
+     *            the message
+     * @param clazz
+     *            the clazz
+     */
     protected ConversionException(String message, Class clazz) {
         this(message, clazz.getName(), null);
     }
 
+    /**
+     * Instantiates a new conversion exception.
+     *
+     * @param message
+     *            the message
+     * @param typeDescription
+     *            the type description
+     * @param exception
+     *            the exception
+     */
     protected ConversionException(String message, String typeDescription, Throwable exception) {
         super(message, exception);
         this.typeDescription = typeDescription;
     }
 
+    /**
+     * Gets the type description.
+     *
+     * @return the type description
+     */
     public String getTypeDescription() {
         return typeDescription;
     }

--- a/src/main/java/org/csveed/bean/conversion/ConversionUtil.java
+++ b/src/main/java/org/csveed/bean/conversion/ConversionUtil.java
@@ -10,20 +10,50 @@
  */
 package org.csveed.bean.conversion;
 
+/**
+ * The Class ConversionUtil.
+ */
 public final class ConversionUtil {
 
+    /**
+     * Instantiates a new conversion util.
+     */
     private ConversionUtil() {
         // Prevent Instantiation of static utils class
     }
 
+    /**
+     * Checks for length.
+     *
+     * @param str
+     *            the str
+     *
+     * @return true, if successful
+     */
     public static boolean hasLength(CharSequence str) {
         return str != null && str.length() > 0;
     }
 
+    /**
+     * Checks for text.
+     *
+     * @param str
+     *            the str
+     *
+     * @return true, if successful
+     */
     public static boolean hasText(String str) {
         return hasText((CharSequence) str);
     }
 
+    /**
+     * Checks for text.
+     *
+     * @param str
+     *            the str
+     *
+     * @return true, if successful
+     */
     public static boolean hasText(CharSequence str) {
         if (!hasLength(str)) {
             return false;
@@ -37,6 +67,14 @@ public final class ConversionUtil {
         return false;
     }
 
+    /**
+     * Trim all whitespace.
+     *
+     * @param str
+     *            the str
+     *
+     * @return the string
+     */
     public static String trimAllWhitespace(String str) {
         if (!hasLength(str)) {
             return str;

--- a/src/main/java/org/csveed/bean/conversion/Converter.java
+++ b/src/main/java/org/csveed/bean/conversion/Converter.java
@@ -20,12 +20,44 @@ package org.csveed.bean.conversion;
  */
 public interface Converter<K> {
 
+    /**
+     * From string.
+     *
+     * @param text
+     *            the text
+     *
+     * @return the k
+     *
+     * @throws Exception
+     *             the exception
+     */
     K fromString(String text) throws Exception;
 
+    /**
+     * To string.
+     *
+     * @param value
+     *            the value
+     *
+     * @return the string
+     *
+     * @throws Exception
+     *             the exception
+     */
     String toString(K value) throws Exception;
 
+    /**
+     * Info on type.
+     *
+     * @return the string
+     */
     String infoOnType();
 
+    /**
+     * Gets the type.
+     *
+     * @return the type
+     */
     Class<K> getType();
 
 }

--- a/src/main/java/org/csveed/bean/conversion/CurrencyConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/CurrencyConverter.java
@@ -12,8 +12,14 @@ package org.csveed.bean.conversion;
 
 import java.util.Currency;
 
+/**
+ * The Class CurrencyConverter.
+ */
 public class CurrencyConverter extends AbstractConverter<Currency> {
 
+    /**
+     * Instantiates a new currency converter.
+     */
     public CurrencyConverter() {
         super(Currency.class);
     }

--- a/src/main/java/org/csveed/bean/conversion/CustomBooleanConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/CustomBooleanConverter.java
@@ -12,30 +12,64 @@ package org.csveed.bean.conversion;
 
 import static org.csveed.bean.conversion.ConversionUtil.hasLength;
 
+/**
+ * The Class CustomBooleanConverter.
+ */
 public class CustomBooleanConverter extends AbstractConverter<Boolean> {
 
+    /** The Constant VALUE_TRUE. */
     public static final String VALUE_TRUE = "true";
+
+    /** The Constant VALUE_FALSE. */
     public static final String VALUE_FALSE = "false";
 
+    /** The Constant VALUE_ON. */
     public static final String VALUE_ON = "on";
+
+    /** The Constant VALUE_OFF. */
     public static final String VALUE_OFF = "off";
 
+    /** The Constant VALUE_YES. */
     public static final String VALUE_YES = "yes";
+
+    /** The Constant VALUE_NO. */
     public static final String VALUE_NO = "no";
 
+    /** The Constant VALUE_1. */
     public static final String VALUE_1 = "1";
+
+    /** The Constant VALUE_0. */
     public static final String VALUE_0 = "0";
 
+    /** The true string. */
     private final String trueString;
 
+    /** The false string. */
     private final String falseString;
 
+    /** The allow empty. */
     private final boolean allowEmpty;
 
+    /**
+     * Instantiates a new custom boolean converter.
+     *
+     * @param allowEmpty
+     *            the allow empty
+     */
     public CustomBooleanConverter(boolean allowEmpty) {
         this(null, null, allowEmpty);
     }
 
+    /**
+     * Instantiates a new custom boolean converter.
+     *
+     * @param trueString
+     *            the true string
+     * @param falseString
+     *            the false string
+     * @param allowEmpty
+     *            the allow empty
+     */
     public CustomBooleanConverter(String trueString, String falseString, boolean allowEmpty) {
         super(Boolean.class);
         this.trueString = trueString;

--- a/src/main/java/org/csveed/bean/conversion/CustomNumberConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/CustomNumberConverter.java
@@ -14,19 +14,49 @@ import static org.csveed.bean.conversion.ConversionUtil.hasText;
 
 import java.text.NumberFormat;
 
+/**
+ * The Class CustomNumberConverter.
+ */
 public class CustomNumberConverter extends AbstractConverter<Number> {
 
+    /** The number class. */
     private final Class<? extends Number> numberClass;
 
+    /** The number format. */
     private final NumberFormat numberFormat;
 
+    /** The allow empty. */
     private final boolean allowEmpty;
 
+    /**
+     * Instantiates a new custom number converter.
+     *
+     * @param numberClass
+     *            the number class
+     * @param allowEmpty
+     *            the allow empty
+     *
+     * @throws IllegalArgumentException
+     *             the illegal argument exception
+     */
     public CustomNumberConverter(Class<? extends Number> numberClass, boolean allowEmpty)
             throws IllegalArgumentException {
         this(numberClass, null, allowEmpty);
     }
 
+    /**
+     * Instantiates a new custom number converter.
+     *
+     * @param numberClass
+     *            the number class
+     * @param numberFormat
+     *            the number format
+     * @param allowEmpty
+     *            the allow empty
+     *
+     * @throws IllegalArgumentException
+     *             the illegal argument exception
+     */
     public CustomNumberConverter(Class<? extends Number> numberClass, NumberFormat numberFormat, boolean allowEmpty)
             throws IllegalArgumentException {
         super(Number.class);
@@ -50,6 +80,14 @@ public class CustomNumberConverter extends AbstractConverter<Number> {
         return determineValue(NumberUtils.parseNumber(text, this.numberClass));
     }
 
+    /**
+     * Determine value.
+     *
+     * @param value
+     *            the value
+     *
+     * @return the number
+     */
     public Number determineValue(Object value) {
         if (value instanceof Number) {
             return NumberUtils.convertNumberToTargetClass((Number) value, this.numberClass);

--- a/src/main/java/org/csveed/bean/conversion/DateConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/DateConverter.java
@@ -17,16 +17,31 @@ import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 
+/**
+ * The Class DateConverter.
+ */
 public class DateConverter extends AbstractConverter<Date> {
 
+    /** The date format. */
     private final DateFormat dateFormat;
 
+    /** The allow empty. */
     private final boolean allowEmpty;
 
+    /** The exact date length. */
     private final int exactDateLength;
 
+    /** The format text. */
     private final String formatText;
 
+    /**
+     * Instantiates a new date converter.
+     *
+     * @param formatText
+     *            the format text
+     * @param allowEmpty
+     *            the allow empty
+     */
     public DateConverter(String formatText, boolean allowEmpty) {
         super(Date.class);
         this.formatText = formatText;

--- a/src/main/java/org/csveed/bean/conversion/DefaultConverters.java
+++ b/src/main/java/org/csveed/bean/conversion/DefaultConverters.java
@@ -21,18 +21,36 @@ import java.util.Map;
 import java.util.TimeZone;
 import java.util.regex.Pattern;
 
+/**
+ * The Class DefaultConverters.
+ */
 public class DefaultConverters {
 
+    /** The converters. */
     private Map<Class<?>, Converter> converters = new HashMap<>();
 
+    /**
+     * Instantiates a new default converters.
+     */
     public DefaultConverters() {
         registerConverters();
     }
 
+    /**
+     * Gets the converter.
+     *
+     * @param clazz
+     *            the clazz
+     *
+     * @return the converter
+     */
     public Converter getConverter(Class clazz) {
         return converters.get(clazz);
     }
 
+    /**
+     * Register converters.
+     */
     protected void registerConverters() {
         addConverter(Charset.class, new CharsetConverter());
         addConverter(Currency.class, new CurrencyConverter());
@@ -74,6 +92,14 @@ public class DefaultConverters {
         addConverter(String.class, new StringConverter());
     }
 
+    /**
+     * Adds the converter.
+     *
+     * @param clazz
+     *            the clazz
+     * @param converter
+     *            the converter
+     */
     protected void addConverter(Class clazz, Converter converter) {
         converters.put(clazz, converter);
     }

--- a/src/main/java/org/csveed/bean/conversion/EasyAbstractConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/EasyAbstractConverter.java
@@ -10,8 +10,20 @@
  */
 package org.csveed.bean.conversion;
 
+/**
+ * The Class EasyAbstractConverter.
+ *
+ * @param <K>
+ *            the key type
+ */
 public abstract class EasyAbstractConverter<K> extends AbstractConverter<K> {
 
+    /**
+     * Instantiates a new easy abstract converter.
+     *
+     * @param clazz
+     *            the clazz
+     */
     protected EasyAbstractConverter(Class<K> clazz) {
         super(clazz);
     }

--- a/src/main/java/org/csveed/bean/conversion/EnumConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/EnumConverter.java
@@ -10,10 +10,23 @@
  */
 package org.csveed.bean.conversion;
 
+/**
+ * The Class EnumConverter.
+ *
+ * @param <T>
+ *            the generic type
+ */
 public class EnumConverter<T extends Enum> extends AbstractConverter<T> {
 
+    /** The enum class. */
     public final Class<T> enumClass;
 
+    /**
+     * Instantiates a new enum converter.
+     *
+     * @param enumClass
+     *            the enum class
+     */
     public EnumConverter(Class<T> enumClass) {
         super(enumClass);
         this.enumClass = enumClass;

--- a/src/main/java/org/csveed/bean/conversion/NoConverterFoundException.java
+++ b/src/main/java/org/csveed/bean/conversion/NoConverterFoundException.java
@@ -10,10 +10,22 @@
  */
 package org.csveed.bean.conversion;
 
+/**
+ * The Class NoConverterFoundException.
+ */
 public class NoConverterFoundException extends ConversionException {
 
+    /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /**
+     * Instantiates a new no converter found exception.
+     *
+     * @param message
+     *            the message
+     * @param propertyType
+     *            the property type
+     */
     public NoConverterFoundException(String message, Class propertyType) {
         super(message, propertyType);
     }

--- a/src/main/java/org/csveed/bean/conversion/NumberUtils.java
+++ b/src/main/java/org/csveed/bean/conversion/NumberUtils.java
@@ -18,12 +18,33 @@ import java.text.DecimalFormat;
 import java.text.NumberFormat;
 import java.text.ParseException;
 
+/**
+ * The Class NumberUtils.
+ */
 public abstract class NumberUtils {
 
+    /**
+     * Instantiates a new number utils.
+     */
     private NumberUtils() {
         // Do not allow instantiation of static utils class
     }
 
+    /**
+     * Convert number to target class.
+     *
+     * @param <T>
+     *            the generic type
+     * @param number
+     *            the number
+     * @param targetClass
+     *            the target class
+     *
+     * @return the t
+     *
+     * @throws IllegalArgumentException
+     *             the illegal argument exception
+     */
     @SuppressWarnings("unchecked")
     public static <T extends Number> T convertNumberToTargetClass(Number number, Class<T> targetClass)
             throws IllegalArgumentException {
@@ -78,11 +99,31 @@ public abstract class NumberUtils {
                 + number.getClass().getName() + "] to unknown target class [" + targetClass.getName() + "]");
     }
 
+    /**
+     * Raise overflow exception.
+     *
+     * @param number
+     *            the number
+     * @param targetClass
+     *            the target class
+     */
     private static void raiseOverflowException(Number number, Class targetClass) {
         throw new IllegalArgumentException("Could not convert number [" + number + "] of type ["
                 + number.getClass().getName() + "] to target class [" + targetClass.getName() + "]: overflow");
     }
 
+    /**
+     * Parses the number.
+     *
+     * @param <T>
+     *            the generic type
+     * @param text
+     *            the text
+     * @param targetClass
+     *            the target class
+     *
+     * @return the t
+     */
     @SuppressWarnings("unchecked")
     public static <T extends Number> T parseNumber(String text, Class<T> targetClass) {
         String trimmed = trimAllWhitespace(text);
@@ -115,6 +156,20 @@ public abstract class NumberUtils {
                 "Cannot convert String [" + text + "] to target class [" + targetClass.getName() + "]");
     }
 
+    /**
+     * Parses the number.
+     *
+     * @param <T>
+     *            the generic type
+     * @param text
+     *            the text
+     * @param targetClass
+     *            the target class
+     * @param numberFormat
+     *            the number format
+     *
+     * @return the t
+     */
     public static <T extends Number> T parseNumber(String text, Class<T> targetClass, NumberFormat numberFormat) {
         if (numberFormat != null) {
             DecimalFormat decimalFormat = null;
@@ -140,11 +195,27 @@ public abstract class NumberUtils {
         return parseNumber(text, targetClass);
     }
 
+    /**
+     * Checks if is hex number.
+     *
+     * @param value
+     *            the value
+     *
+     * @return true, if is hex number
+     */
     private static boolean isHexNumber(String value) {
         int index = value.startsWith("-") ? 1 : 0;
         return value.startsWith("0x", index) || value.startsWith("0X", index) || value.startsWith("#", index);
     }
 
+    /**
+     * Decode big integer.
+     *
+     * @param value
+     *            the value
+     *
+     * @return the big integer
+     */
     private static BigInteger decodeBigInteger(String value) {
         int radix = 10;
         int index = 0;

--- a/src/main/java/org/csveed/bean/conversion/PatternConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/PatternConverter.java
@@ -12,14 +12,27 @@ package org.csveed.bean.conversion;
 
 import java.util.regex.Pattern;
 
+/**
+ * The Class PatternConverter.
+ */
 public class PatternConverter extends AbstractConverter<Pattern> {
 
+    /** The flags. */
     private final int flags;
 
+    /**
+     * Instantiates a new pattern converter.
+     */
     public PatternConverter() {
         this(0);
     }
 
+    /**
+     * Instantiates a new pattern converter.
+     *
+     * @param flags
+     *            the flags
+     */
     public PatternConverter(int flags) {
         super(Pattern.class);
         this.flags = flags;

--- a/src/main/java/org/csveed/bean/conversion/StringConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/StringConverter.java
@@ -10,8 +10,14 @@
  */
 package org.csveed.bean.conversion;
 
+/**
+ * The Class StringConverter.
+ */
 public class StringConverter extends AbstractConverter<String> {
 
+    /**
+     * Instantiates a new string converter.
+     */
     public StringConverter() {
         super(String.class);
     }

--- a/src/main/java/org/csveed/bean/conversion/TimeZoneConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/TimeZoneConverter.java
@@ -12,8 +12,14 @@ package org.csveed.bean.conversion;
 
 import java.util.TimeZone;
 
+/**
+ * The Class TimeZoneConverter.
+ */
 public class TimeZoneConverter extends AbstractConverter<TimeZone> {
 
+    /**
+     * Instantiates a new time zone converter.
+     */
     public TimeZoneConverter() {
         super(TimeZone.class);
     }

--- a/src/main/java/org/csveed/common/Column.java
+++ b/src/main/java/org/csveed/common/Column.java
@@ -16,30 +16,59 @@ import org.csveed.api.Header;
 import org.csveed.report.CsvException;
 import org.csveed.report.GeneralError;
 
+/**
+ * The Class Column.
+ */
 public class Column implements Comparable<Column> {
 
+    /** The Constant FIRST_COLUMN_INDEX. */
     public static final int FIRST_COLUMN_INDEX = 1;
 
+    /** The column index. */
     private int columnIndex = -1;
 
+    /** The column name. */
     private String columnName;
 
+    /** The header. */
     private Header header;
 
+    /** The key. */
     private ColumnKey key;
 
+    /**
+     * Instantiates a new column.
+     *
+     * @param columnName
+     *            the column name
+     */
     public Column(String columnName) {
         setColumnName(columnName);
     }
 
+    /**
+     * Instantiates a new column.
+     */
     public Column() {
         this(FIRST_COLUMN_INDEX);
     }
 
+    /**
+     * Instantiates a new column.
+     *
+     * @param column
+     *            the column
+     */
     public Column(Column column) {
         setColumnIndex(column.getColumnIndex());
     }
 
+    /**
+     * Instantiates a new column.
+     *
+     * @param columnIndex
+     *            the column index
+     */
     public Column(int columnIndex) {
         if (columnIndex <= 0) {
             throw new CsvException(
@@ -48,6 +77,14 @@ public class Column implements Comparable<Column> {
         setColumnIndex(columnIndex);
     }
 
+    /**
+     * Column index to excel column.
+     *
+     * @param columnIndex
+     *            the column index
+     *
+     * @return the string
+     */
     private String columnIndexToExcelColumn(int columnIndex) {
         StringBuilder excelColumn = new StringBuilder();
         while (columnIndex % 26 > 0) {
@@ -57,6 +94,14 @@ public class Column implements Comparable<Column> {
         return excelColumn.toString();
     }
 
+    /**
+     * Sets the header.
+     *
+     * @param header
+     *            the header
+     *
+     * @return the column
+     */
     public Column setHeader(Header header) {
         this.header = header;
         if (this.header != null) {
@@ -65,40 +110,88 @@ public class Column implements Comparable<Column> {
         return this;
     }
 
+    /**
+     * Sets the column index.
+     *
+     * @param columnIndex
+     *            the new column index
+     */
     public void setColumnIndex(int columnIndex) {
         this.columnIndex = columnIndex;
         setKey(new ColumnIndexKey(this.columnIndex));
     }
 
+    /**
+     * Sets the column name.
+     *
+     * @param columnName
+     *            the new column name
+     */
     public void setColumnName(String columnName) {
         this.columnName = columnName.toLowerCase(Locale.getDefault());
         setKey(new ColumnNameKey(this.columnName));
     }
 
+    /**
+     * Sets the key.
+     *
+     * @param key
+     *            the new key
+     */
     public void setKey(ColumnKey key) {
         this.key = key;
     }
 
+    /**
+     * Gets the excel column.
+     *
+     * @return the excel column
+     */
     public String getExcelColumn() {
         return columnIndexToExcelColumn(this.columnIndex);
     }
 
+    /**
+     * Gets the column index.
+     *
+     * @return the column index
+     */
     public int getColumnIndex() {
         return this.columnIndex;
     }
 
+    /**
+     * Gets the column name.
+     *
+     * @return the column name
+     */
     public String getColumnName() {
         return this.columnName;
     }
 
+    /**
+     * Next column.
+     *
+     * @return the column
+     */
     public Column nextColumn() {
         return new Column(this.getColumnIndex() + 1).setHeader(header);
     }
 
+    /**
+     * Next line.
+     *
+     * @return the column
+     */
     public Column nextLine() {
         return new Column().setHeader(header);
     }
 
+    /**
+     * Gets the column text.
+     *
+     * @return the column text
+     */
     public String getColumnText() {
         return (columnIndex == -1 ? "" : " index " + columnIndex + " (" + getExcelColumn() + ")")
                 + (columnName == null ? "" : " name \"" + columnName + "\"");

--- a/src/main/java/org/csveed/common/ColumnExcel.java
+++ b/src/main/java/org/csveed/common/ColumnExcel.java
@@ -12,12 +12,29 @@ package org.csveed.common;
 
 import java.util.Locale;
 
+/**
+ * The Class ColumnExcel.
+ */
 public class ColumnExcel extends Column {
 
+    /**
+     * Instantiates a new column excel.
+     *
+     * @param columnExcel
+     *            the column excel
+     */
     public ColumnExcel(String columnExcel) {
         super(excelColumnToColumnIndex(columnExcel));
     }
 
+    /**
+     * Excel column to column index.
+     *
+     * @param excelColumn
+     *            the excel column
+     *
+     * @return the int
+     */
     private static int excelColumnToColumnIndex(String excelColumn) {
         excelColumn = excelColumn.toUpperCase(Locale.getDefault());
         int sum = 0;

--- a/src/main/java/org/csveed/common/ColumnIndexKey.java
+++ b/src/main/java/org/csveed/common/ColumnIndexKey.java
@@ -10,10 +10,20 @@
  */
 package org.csveed.common;
 
+/**
+ * The Class ColumnIndexKey.
+ */
 public class ColumnIndexKey extends ColumnKey {
 
+    /** The column index. */
     private final Integer columnIndex;
 
+    /**
+     * Instantiates a new column index key.
+     *
+     * @param columnIndex
+     *            the column index
+     */
     public ColumnIndexKey(int columnIndex) {
         this.columnIndex = columnIndex;
     }

--- a/src/main/java/org/csveed/common/ColumnKey.java
+++ b/src/main/java/org/csveed/common/ColumnKey.java
@@ -10,14 +10,38 @@
  */
 package org.csveed.common;
 
+/**
+ * The Class ColumnKey.
+ */
 public abstract class ColumnKey implements Comparable<ColumnKey> {
 
+    /**
+     * Gets the priority.
+     *
+     * @return the priority
+     */
     public abstract Integer getPriority();
 
+    /**
+     * Same key type.
+     *
+     * @param columnKey
+     *            the column key
+     *
+     * @return true, if successful
+     */
     public boolean sameKeyType(ColumnKey columnKey) {
         return getPriority().equals(columnKey.getPriority());
     }
 
+    /**
+     * Key type compare.
+     *
+     * @param columnKey
+     *            the column key
+     *
+     * @return the int
+     */
     public int keyTypeCompare(ColumnKey columnKey) {
         return getPriority().compareTo(columnKey.getPriority());
     }

--- a/src/main/java/org/csveed/common/ColumnNameKey.java
+++ b/src/main/java/org/csveed/common/ColumnNameKey.java
@@ -10,10 +10,20 @@
  */
 package org.csveed.common;
 
+/**
+ * The Class ColumnNameKey.
+ */
 public class ColumnNameKey extends ColumnKey {
 
+    /** The column name. */
     private final String columnName;
 
+    /**
+     * Instantiates a new column name key.
+     *
+     * @param columnName
+     *            the column name
+     */
     public ColumnNameKey(String columnName) {
         this.columnName = columnName;
     }

--- a/src/main/java/org/csveed/report/AbstractCsvError.java
+++ b/src/main/java/org/csveed/report/AbstractCsvError.java
@@ -13,10 +13,20 @@ package org.csveed.report;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * The Class AbstractCsvError.
+ */
 public abstract class AbstractCsvError implements CsvError {
 
+    /** The message. */
     private String message;
 
+    /**
+     * Instantiates a new abstract csv error.
+     *
+     * @param message
+     *            the message
+     */
     protected AbstractCsvError(String message) {
         this.message = message;
     }
@@ -26,6 +36,11 @@ public abstract class AbstractCsvError implements CsvError {
         return this.message;
     }
 
+    /**
+     * Gets the message as list.
+     *
+     * @return the message as list
+     */
     protected List<String> getMessageAsList() {
         List<String> lines = new ArrayList<>();
         lines.add(getMessage());

--- a/src/main/java/org/csveed/report/CsvException.java
+++ b/src/main/java/org/csveed/report/CsvException.java
@@ -13,14 +13,26 @@ package org.csveed.report;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The Class CsvException.
+ */
 public class CsvException extends RuntimeException {
 
+    /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /** The Constant LOG. */
     private static final Logger LOG = LoggerFactory.getLogger(CsvException.class);
 
+    /** The error. */
     private CsvError error;
 
+    /**
+     * Instantiates a new csv exception.
+     *
+     * @param error
+     *            the error
+     */
     public CsvException(CsvError error) {
         this.error = error;
         for (String line : error.getPrintableLines()) {
@@ -28,6 +40,11 @@ public class CsvException extends RuntimeException {
         }
     }
 
+    /**
+     * Gets the error.
+     *
+     * @return the error
+     */
     public CsvError getError() {
         return this.error;
     }

--- a/src/main/java/org/csveed/report/GeneralError.java
+++ b/src/main/java/org/csveed/report/GeneralError.java
@@ -13,8 +13,17 @@ package org.csveed.report;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * The Class GeneralError.
+ */
 public class GeneralError extends AbstractCsvError {
 
+    /**
+     * Instantiates a new general error.
+     *
+     * @param message
+     *            the message
+     */
     public GeneralError(String message) {
         super(message);
     }

--- a/src/main/java/org/csveed/report/RowError.java
+++ b/src/main/java/org/csveed/report/RowError.java
@@ -12,18 +12,38 @@ package org.csveed.report;
 
 import java.util.List;
 
+/**
+ * The Class RowError.
+ */
 public class RowError extends AbstractCsvError {
 
+    /** The report. */
     private RowReport report;
 
+    /** The line number. */
     private int lineNumber;
 
+    /**
+     * Instantiates a new row error.
+     *
+     * @param message
+     *            the message
+     * @param report
+     *            the report
+     * @param lineNumber
+     *            the line number
+     */
     public RowError(String message, RowReport report, int lineNumber) {
         super(message);
         this.report = report;
         this.lineNumber = lineNumber;
     }
 
+    /**
+     * Gets the report.
+     *
+     * @return the report
+     */
     public RowReport getReport() {
         return report;
     }

--- a/src/main/java/org/csveed/report/RowPart.java
+++ b/src/main/java/org/csveed/report/RowPart.java
@@ -10,21 +10,44 @@
  */
 package org.csveed.report;
 
+/**
+ * The Class RowPart.
+ */
 public class RowPart {
 
+    /** The token. */
     private String token;
 
+    /** The highlight. */
     private boolean highlight;
 
+    /**
+     * Instantiates a new row part.
+     *
+     * @param token
+     *            the token
+     * @param highlight
+     *            the highlight
+     */
     public RowPart(String token, boolean highlight) {
         this.token = token;
         this.highlight = highlight;
     }
 
+    /**
+     * Gets the token.
+     *
+     * @return the token
+     */
     public String getToken() {
         return token;
     }
 
+    /**
+     * Checks if is highlight.
+     *
+     * @return true, if is highlight
+     */
     public boolean isHighlight() {
         return highlight;
     }

--- a/src/main/java/org/csveed/report/RowReport.java
+++ b/src/main/java/org/csveed/report/RowReport.java
@@ -13,32 +13,68 @@ package org.csveed.report;
 import java.util.ArrayList;
 import java.util.List;
 
+/**
+ * The Class RowReport.
+ */
 public class RowReport {
 
+    /** The row. */
     private String row;
 
+    /** The start. */
     private int start;
 
+    /** The end. */
     private int end;
 
+    /**
+     * Instantiates a new row report.
+     *
+     * @param row
+     *            the row
+     * @param start
+     *            the start
+     * @param end
+     *            the end
+     */
     public RowReport(String row, int start, int end) {
         this.row = row;
         this.start = start;
         this.end = start == end && start < row.length() ? start + 1 : end;
     }
 
+    /**
+     * Gets the row.
+     *
+     * @return the row
+     */
     public String getRow() {
         return row;
     }
 
+    /**
+     * Gets the start.
+     *
+     * @return the start
+     */
     public int getStart() {
         return start;
     }
 
+    /**
+     * Gets the end.
+     *
+     * @return the end
+     */
     public int getEnd() {
         return end;
     }
 
+    /**
+     * Tokenize.
+     *
+     * @return the list
+     */
     public List<RowPart> tokenize() {
         List<RowPart> lines = new ArrayList<>();
         if (start > 0) {
@@ -53,6 +89,11 @@ public class RowReport {
         return lines;
     }
 
+    /**
+     * Gets the printable lines.
+     *
+     * @return the printable lines
+     */
     public List<String> getPrintableLines() {
         List<String> lines = new ArrayList<>();
 
@@ -64,6 +105,14 @@ public class RowReport {
         return lines;
     }
 
+    /**
+     * Creates the content line.
+     *
+     * @param parts
+     *            the parts
+     *
+     * @return the string
+     */
     private String createContentLine(List<RowPart> parts) {
         StringBuilder line = new StringBuilder();
         for (RowPart token : parts) {
@@ -72,6 +121,14 @@ public class RowReport {
         return line.toString();
     }
 
+    /**
+     * Creates the focus line.
+     *
+     * @param parts
+     *            the parts
+     *
+     * @return the string
+     */
     private String createFocusLine(List<RowPart> parts) {
         StringBuilder line = new StringBuilder();
         boolean placedMarkers = false;
@@ -89,6 +146,14 @@ public class RowReport {
         return line.toString();
     }
 
+    /**
+     * Prints the empty part.
+     *
+     * @param token
+     *            the token
+     *
+     * @return the string
+     */
     private String printEmptyPart(RowPart token) {
         StringBuilder linePart = new StringBuilder();
         for (int i = 0; i < token.getToken().length(); i++) {
@@ -97,6 +162,14 @@ public class RowReport {
         return linePart.toString();
     }
 
+    /**
+     * Prints the underscored part.
+     *
+     * @param token
+     *            the token
+     *
+     * @return the string
+     */
     private String printUnderscoredPart(RowPart token) {
         StringBuilder linePart = new StringBuilder();
         for (int i = 0; i < token.getToken().length(); i++) {

--- a/src/main/java/org/csveed/row/CellPositionInRow.java
+++ b/src/main/java/org/csveed/row/CellPositionInRow.java
@@ -10,24 +10,51 @@
  */
 package org.csveed.row;
 
+/**
+ * The Class CellPositionInRow.
+ */
 public class CellPositionInRow {
 
+    /** The start. */
     private int start;
 
+    /** The end. */
     private int end;
 
+    /**
+     * Gets the start.
+     *
+     * @return the start
+     */
     public int getStart() {
         return start;
     }
 
+    /**
+     * Sets the start.
+     *
+     * @param start
+     *            the new start
+     */
     public void setStart(int start) {
         this.start = start;
     }
 
+    /**
+     * Gets the end.
+     *
+     * @return the end
+     */
     public int getEnd() {
         return end;
     }
 
+    /**
+     * Sets the end.
+     *
+     * @param end
+     *            the new end
+     */
     public void setEnd(int end) {
         this.end = end;
     }

--- a/src/main/java/org/csveed/row/HeaderImpl.java
+++ b/src/main/java/org/csveed/row/HeaderImpl.java
@@ -21,12 +21,26 @@ import org.csveed.report.CsvException;
 import org.csveed.report.GeneralError;
 import org.csveed.report.RowReport;
 
+/**
+ * The Class HeaderImpl.
+ */
 public class HeaderImpl implements Header {
 
+    /** The header. */
     private Line header;
+
+    /** The index to name. */
     private Map<Column, String> indexToName = new HashMap<>();
+
+    /** The name to index. */
     private Map<String, Column> nameToIndex = new HashMap<>();
 
+    /**
+     * Instantiates a new header impl.
+     *
+     * @param row
+     *            the row
+     */
     public HeaderImpl(Line row) {
         this.header = row;
         Column currentColumn = new Column();

--- a/src/main/java/org/csveed/row/Line.java
+++ b/src/main/java/org/csveed/row/Line.java
@@ -13,14 +13,43 @@ package org.csveed.row;
 import org.csveed.common.Column;
 import org.csveed.report.RowReport;
 
+/**
+ * The Interface Line.
+ */
 public interface Line extends Iterable<String> {
 
+    /**
+     * Size.
+     *
+     * @return the int
+     */
     int size();
 
+    /**
+     * Gets the.
+     *
+     * @param index
+     *            the index
+     *
+     * @return the string
+     */
     String get(int index);
 
+    /**
+     * Report on end of line.
+     *
+     * @return the row report
+     */
     RowReport reportOnEndOfLine();
 
+    /**
+     * Report on column.
+     *
+     * @param column
+     *            the column
+     *
+     * @return the row report
+     */
     RowReport reportOnColumn(Column column);
 
 }

--- a/src/main/java/org/csveed/row/LineWithInfo.java
+++ b/src/main/java/org/csveed/row/LineWithInfo.java
@@ -21,20 +21,35 @@ import org.csveed.report.RowReport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The Class LineWithInfo.
+ */
 public class LineWithInfo implements Line {
 
+    /** The Constant LOG. */
     private static final Logger LOG = LoggerFactory.getLogger(LineWithInfo.class);
 
+    /** The cells. */
     private List<String> cells = new ArrayList<>();
 
+    /** The original line. */
     private StringBuilder originalLine = new StringBuilder();
 
+    /** The cell positions. */
     private Map<Column, CellPositionInRow> cellPositions = new TreeMap<>();
 
+    /** The print length. */
     private int printLength;
 
+    /** The current column. */
     private Column currentColumn = new Column();
 
+    /**
+     * Adds the cell.
+     *
+     * @param cell
+     *            the cell
+     */
     public void addCell(String cell) {
         this.cells.add(cell);
         if (cell == null || "".equals(cell)) {
@@ -48,17 +63,31 @@ public class LineWithInfo implements Line {
         return cells.iterator();
     }
 
+    /**
+     * Mark start of column.
+     */
     public void markStartOfColumn() {
         LOG.debug("Start of column: {}", printLength);
         getCellPosition(currentColumn).setStart(printLength);
     }
 
+    /**
+     * Mark end of column.
+     */
     protected void markEndOfColumn() {
         LOG.debug("End of column: {}", printLength);
         getCellPosition(currentColumn).setEnd(printLength);
         currentColumn = currentColumn.nextColumn();
     }
 
+    /**
+     * Gets the cell position.
+     *
+     * @param column
+     *            the column
+     *
+     * @return the cell position
+     */
     protected CellPositionInRow getCellPosition(Column column) {
         CellPositionInRow cellPosition = cellPositions.get(column);
         if (cellPosition == null) {
@@ -68,12 +97,26 @@ public class LineWithInfo implements Line {
         return cellPosition;
     }
 
+    /**
+     * Adds the character.
+     *
+     * @param symbol
+     *            the symbol
+     */
     public void addCharacter(int symbol) {
         String printableChar = convertToPrintable(symbol);
         originalLine.append(printableChar);
         printLength += printableChar.length();
     }
 
+    /**
+     * Convert to printable.
+     *
+     * @param symbol
+     *            the symbol
+     *
+     * @return the string
+     */
     public String convertToPrintable(int symbol) {
         switch (symbol) {
             case -1:

--- a/src/main/java/org/csveed/row/RowImpl.java
+++ b/src/main/java/org/csveed/row/RowImpl.java
@@ -19,12 +19,25 @@ import org.csveed.report.CsvException;
 import org.csveed.report.GeneralError;
 import org.csveed.report.RowReport;
 
+/**
+ * The Class RowImpl.
+ */
 public class RowImpl implements Row {
 
+    /** The line. */
     private Line line;
 
+    /** The header. */
     private Header header;
 
+    /**
+     * Instantiates a new row impl.
+     *
+     * @param line
+     *            the line
+     * @param header
+     *            the header
+     */
     public RowImpl(Line line, Header header) {
         this.line = line;
         this.header = header;

--- a/src/main/java/org/csveed/row/RowInstructionsImpl.java
+++ b/src/main/java/org/csveed/row/RowInstructionsImpl.java
@@ -15,20 +15,32 @@ import org.csveed.token.SymbolMapping;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The Class RowInstructionsImpl.
+ */
 public class RowInstructionsImpl implements RowInstructions {
 
+    /** The Constant LOG. */
     private static final Logger LOG = LoggerFactory.getLogger(RowInstructionsImpl.class);
 
+    /** The symbol mapping. */
     private SymbolMapping symbolMapping = new SymbolMapping();
 
+    /** The use header. */
     private boolean useHeader = true;
 
+    /** The skip empty lines. */
     private boolean skipEmptyLines = true;
 
+    /** The settings logged. */
     private boolean settingsLogged;
 
+    /** The quote fields. */
     private boolean quoteFields = true;
 
+    /**
+     * Log settings.
+     */
     public void logSettings() {
         if (settingsLogged) {
             return;
@@ -38,10 +50,20 @@ public class RowInstructionsImpl implements RowInstructions {
         settingsLogged = true;
     }
 
+    /**
+     * Gets the symbol mapping.
+     *
+     * @return the symbol mapping
+     */
     public SymbolMapping getSymbolMapping() {
         return symbolMapping;
     }
 
+    /**
+     * Checks if is skip empty lines.
+     *
+     * @return true, if is skip empty lines
+     */
     public boolean isSkipEmptyLines() {
         return skipEmptyLines;
     }

--- a/src/main/java/org/csveed/row/RowReaderImpl.java
+++ b/src/main/java/org/csveed/row/RowReaderImpl.java
@@ -30,20 +30,39 @@ import org.csveed.token.ParseStateMachine;
  */
 public class RowReaderImpl implements RowReader {
 
+    /** The state machine. */
     private ParseStateMachine stateMachine = new ParseStateMachine();
 
+    /** The row instructions. */
     private RowInstructionsImpl rowInstructions;
 
+    /** The max number of columns. */
     private int maxNumberOfColumns = -1;
 
+    /** The header. */
     private HeaderImpl header;
 
+    /** The reader. */
     private Reader reader;
 
+    /**
+     * Instantiates a new row reader impl.
+     *
+     * @param reader
+     *            the reader
+     */
     public RowReaderImpl(Reader reader) {
         this(reader, new RowInstructionsImpl());
     }
 
+    /**
+     * Instantiates a new row reader impl.
+     *
+     * @param reader
+     *            the reader
+     * @param instructionsInterface
+     *            the instructions interface
+     */
     public RowReaderImpl(Reader reader, RowInstructions instructionsInterface) {
         this.reader = reader;
         this.rowInstructions = (RowInstructionsImpl) instructionsInterface;
@@ -83,6 +102,11 @@ public class RowReaderImpl implements RowReader {
         return header == null && rowInstructions.isUseHeader() ? readHeader() : header;
     }
 
+    /**
+     * Gets the max number of columns.
+     *
+     * @return the max number of columns
+     */
     public int getMaxNumberOfColumns() {
         return this.maxNumberOfColumns;
     }
@@ -100,6 +124,12 @@ public class RowReaderImpl implements RowReader {
         return header;
     }
 
+    /**
+     * Check number of columns.
+     *
+     * @param unmappedLine
+     *            the unmapped line
+     */
     private void checkNumberOfColumns(Line unmappedLine) {
         if (maxNumberOfColumns == -1) {
             maxNumberOfColumns = header == null ? unmappedLine.size() : header.size();
@@ -115,11 +145,19 @@ public class RowReaderImpl implements RowReader {
         return stateMachine.isFinished();
     }
 
+    /**
+     * Log settings.
+     */
     protected void logSettings() {
         rowInstructions.logSettings();
         this.stateMachine.getSymbolMapping().logSettings();
     }
 
+    /**
+     * Read bare line.
+     *
+     * @return the line
+     */
     protected Line readBareLine() {
         logSettings();
 

--- a/src/main/java/org/csveed/row/RowWriter.java
+++ b/src/main/java/org/csveed/row/RowWriter.java
@@ -15,6 +15,9 @@ import java.util.Collection;
 import org.csveed.api.Header;
 import org.csveed.api.Row;
 
+/**
+ * The Interface RowWriter.
+ */
 public interface RowWriter {
 
     /**

--- a/src/main/java/org/csveed/row/RowWriterImpl.java
+++ b/src/main/java/org/csveed/row/RowWriterImpl.java
@@ -22,20 +22,41 @@ import org.csveed.report.GeneralError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The Class RowWriterImpl.
+ */
 public class RowWriterImpl implements RowWriter {
 
+    /** The Constant LOG. */
     private static final Logger LOG = LoggerFactory.getLogger(RowWriterImpl.class);
 
+    /** The writer. */
     private final Writer writer;
 
+    /** The row instructions. */
     private RowInstructions rowInstructions;
 
+    /** The header. */
     private Header header;
 
+    /**
+     * Instantiates a new row writer impl.
+     *
+     * @param writer
+     *            the writer
+     */
     public RowWriterImpl(Writer writer) {
         this(writer, new RowInstructionsImpl());
     }
 
+    /**
+     * Instantiates a new row writer impl.
+     *
+     * @param writer
+     *            the writer
+     * @param rowInstructions
+     *            the row instructions
+     */
     public RowWriterImpl(Writer writer, RowInstructions rowInstructions) {
         this.writer = writer;
         this.rowInstructions = rowInstructions;
@@ -90,6 +111,12 @@ public class RowWriterImpl implements RowWriter {
         return this.rowInstructions;
     }
 
+    /**
+     * Write cells.
+     *
+     * @param cells
+     *            the cells
+     */
     private void writeCells(Iterator<String> cells) {
         int columnPosition = 1;
         try {
@@ -116,14 +143,35 @@ public class RowWriterImpl implements RowWriter {
         }
     }
 
+    /**
+     * Write EOL.
+     *
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     */
     private void writeEOL() throws IOException {
         writer.write(rowInstructions.getEndOfLine());
     }
 
+    /**
+     * Write separator.
+     *
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     */
     private void writeSeparator() throws IOException {
         writer.write(rowInstructions.getSeparator());
     }
 
+    /**
+     * Write quoted cell.
+     *
+     * @param cell
+     *            the cell
+     *
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     */
     private void writeQuotedCell(String cell) throws IOException {
         writer.write(rowInstructions.getQuote());
         String searchString = Character.toString(rowInstructions.getQuote());
@@ -133,10 +181,27 @@ public class RowWriterImpl implements RowWriter {
         writer.write(rowInstructions.getQuote());
     }
 
+    /**
+     * Write cell.
+     *
+     * @param cell
+     *            the cell
+     *
+     * @throws IOException
+     *             Signals that an I/O exception has occurred.
+     */
     private void writeCell(String cell) throws IOException {
         writer.write(cell);
     }
 
+    /**
+     * Convert to line.
+     *
+     * @param cells
+     *            the cells
+     *
+     * @return the line with info
+     */
     private LineWithInfo convertToLine(String[] cells) {
         LineWithInfo line = new LineWithInfo();
         for (String cell : cells) {

--- a/src/main/java/org/csveed/token/EncounteredSymbol.java
+++ b/src/main/java/org/csveed/token/EncounteredSymbol.java
@@ -10,31 +10,83 @@
  */
 package org.csveed.token;
 
+/**
+ * The Enum EncounteredSymbol.
+ */
 public enum EncounteredSymbol {
-    SPACE_SYMBOL, SEPARATOR_SYMBOL, QUOTE_SYMBOL(true), ESCAPE_SYMBOL(true), EOL_SYMBOL, EOL_SYMBOL_TRASH(false, true),
-    OTHER_SYMBOL, BOM_SYMBOL(false, true), END_OF_FILE_SYMBOL, COMMENT_SYMBOL;
 
+    /** The space symbol. */
+    SPACE_SYMBOL,
+    /** The separator symbol. */
+    SEPARATOR_SYMBOL,
+    /** The quote symbol. */
+    QUOTE_SYMBOL(true),
+    /** The escape symbol. */
+    ESCAPE_SYMBOL(true),
+    /** The eol symbol. */
+    EOL_SYMBOL,
+    /** The eol symbol trash. */
+    EOL_SYMBOL_TRASH(false, true),
+
+    /** The other symbol. */
+    OTHER_SYMBOL,
+    /** The bom symbol. */
+    BOM_SYMBOL(false, true),
+    /** The end of file symbol. */
+    END_OF_FILE_SYMBOL,
+    /** The comment symbol. */
+    COMMENT_SYMBOL;
+
+    /** The check for similar escape and quote. */
     private final boolean checkForSimilarEscapeAndQuote;
 
+    /** The trash. */
     private final boolean trash;
 
+    /**
+     * Instantiates a new encountered symbol.
+     */
     EncounteredSymbol() {
         this(false, false);
     }
 
+    /**
+     * Instantiates a new encountered symbol.
+     *
+     * @param checkForSimilarEscapeAndQuote
+     *            the check for similar escape and quote
+     */
     EncounteredSymbol(boolean checkForSimilarEscapeAndQuote) {
         this(checkForSimilarEscapeAndQuote, false);
     }
 
+    /**
+     * Instantiates a new encountered symbol.
+     *
+     * @param checkForSimilarEscapeAndQuote
+     *            the check for similar escape and quote
+     * @param trash
+     *            the trash
+     */
     EncounteredSymbol(boolean checkForSimilarEscapeAndQuote, boolean trash) {
         this.checkForSimilarEscapeAndQuote = checkForSimilarEscapeAndQuote;
         this.trash = trash;
     }
 
+    /**
+     * Checks if is check for similar escape and quote.
+     *
+     * @return true, if is check for similar escape and quote
+     */
     public boolean isCheckForSimilarEscapeAndQuote() {
         return this.checkForSimilarEscapeAndQuote;
     }
 
+    /**
+     * Checks if is trash.
+     *
+     * @return true, if is trash
+     */
     public boolean isTrash() {
         return this.trash;
     }

--- a/src/main/java/org/csveed/token/ParseException.java
+++ b/src/main/java/org/csveed/token/ParseException.java
@@ -10,30 +10,62 @@
  */
 package org.csveed.token;
 
+/**
+ * The Class ParseException.
+ */
 public class ParseException extends Exception {
 
+    /** The Constant serialVersionUID. */
     private static final long serialVersionUID = 1L;
 
+    /** The state. */
     private final ParseState state;
 
+    /** The symbol. */
     private final EncounteredSymbol symbol;
 
+    /** The symbol character. */
     private final int symbolCharacter;
 
+    /**
+     * Instantiates a new parses the exception.
+     *
+     * @param state
+     *            the state
+     * @param symbolCharacter
+     *            the symbol character
+     * @param symbol
+     *            the symbol
+     */
     public ParseException(ParseState state, int symbolCharacter, EncounteredSymbol symbol) {
         this.state = state;
         this.symbolCharacter = symbolCharacter;
         this.symbol = symbol;
     }
 
+    /**
+     * Gets the state.
+     *
+     * @return the state
+     */
     public ParseState getState() {
         return state;
     }
 
+    /**
+     * Gets the symbol.
+     *
+     * @return the symbol
+     */
     public EncounteredSymbol getSymbol() {
         return symbol;
     }
 
+    /**
+     * Gets the symbol character.
+     *
+     * @return the symbol character
+     */
     public int getSymbolCharacter() {
         return symbolCharacter;
     }

--- a/src/main/java/org/csveed/token/ParseState.java
+++ b/src/main/java/org/csveed/token/ParseState.java
@@ -10,14 +10,51 @@
  */
 package org.csveed.token;
 
+/**
+ * The Enum ParseState.
+ */
 public enum ParseState {
-    SKIP_LINE(false, false, false, false, true), SKIP_LINE_FINISHED(false, true, false, false, true),
-    COMMENT_LINE(false, false, false, false, true), COMMENT_LINE_FINISHED(false, true, false, false, true),
-    START_OF_LINE(false, false, false, false, false), OUTSIDE_BEFORE_FIELD(false, false, false, false, false),
-    OUTSIDE_AFTER_FIELD(false, false, false, false, false), INSIDE_FIELD(true, false, false, false, false),
+
+    /** The skip line. */
+    SKIP_LINE(false, false, false, false, true),
+
+    /** The skip line finished. */
+    SKIP_LINE_FINISHED(false, true, false, false, true),
+
+    /** The comment line. */
+    COMMENT_LINE(false, false, false, false, true),
+
+    /** The comment line finished. */
+    COMMENT_LINE_FINISHED(false, true, false, false, true),
+
+    /** The start of line. */
+    START_OF_LINE(false, false, false, false, false),
+
+    /** The outside before field. */
+    OUTSIDE_BEFORE_FIELD(false, false, false, false, false),
+
+    /** The outside after field. */
+    OUTSIDE_AFTER_FIELD(false, false, false, false, false),
+
+    /** The inside field. */
+    INSIDE_FIELD(true, false, false, false, false),
+
+    /** The first char inside quoted field. */
     FIRST_CHAR_INSIDE_QUOTED_FIELD(false, false, false, true, false),
-    INSIDE_QUOTED_FIELD(true, false, false, true, false), ESCAPING(false, false, false, false, false),
-    SEPARATOR(false, false, true, false, false), LINE_FINISHED(false, true, true, false, false),
+
+    /** The inside quoted field. */
+    INSIDE_QUOTED_FIELD(true, false, false, true, false),
+
+    /** The escaping. */
+    ESCAPING(false, false, false, false, false),
+
+    /** The separator. */
+    SEPARATOR(false, false, true, false, false),
+
+    /** The line finished. */
+    LINE_FINISHED(false, true, true, false, false),
+
+    /** The finished. */
     FINISHED(false, true, true, false, false);
 
     /** When in this state, encountered symbols must be made part of the token. */
@@ -35,6 +72,20 @@ public enum ParseState {
     /** When in this state, ignore the entire line. */
     private final boolean ignore;
 
+    /**
+     * Instantiates a new parses the state.
+     *
+     * @param tokenize
+     *            the tokenize
+     * @param lineFinished
+     *            the line finished
+     * @param popToken
+     *            the pop token
+     * @param upgradeQuoteToEscape
+     *            the upgrade quote to escape
+     * @param ignore
+     *            the ignore
+     */
     ParseState(final boolean tokenize, final boolean lineFinished, final boolean popToken,
             final boolean upgradeQuoteToEscape, final boolean ignore) {
         this.tokenize = tokenize;
@@ -44,26 +95,56 @@ public enum ParseState {
         this.ignore = ignore;
     }
 
+    /**
+     * Checks if is tokenize.
+     *
+     * @return true, if is tokenize
+     */
     public boolean isTokenize() {
         return this.tokenize;
     }
 
+    /**
+     * Checks if is line finished.
+     *
+     * @return true, if is line finished
+     */
     public boolean isLineFinished() {
         return this.lineFinished;
     }
 
+    /**
+     * Checks if is pop token.
+     *
+     * @return true, if is pop token
+     */
     public boolean isPopToken() {
         return this.popToken;
     }
 
+    /**
+     * Checks if is upgrade quote to escape.
+     *
+     * @return true, if is upgrade quote to escape
+     */
     public boolean isUpgradeQuoteToEscape() {
         return this.upgradeQuoteToEscape;
     }
 
+    /**
+     * Checks if is ignore.
+     *
+     * @return true, if is ignore
+     */
     public boolean isIgnore() {
         return this.ignore;
     }
 
+    /**
+     * Trim.
+     *
+     * @return true, if successful
+     */
     public boolean trim() {
         return this == INSIDE_FIELD;
     }

--- a/src/main/java/org/csveed/token/ParseStateMachine.java
+++ b/src/main/java/org/csveed/token/ParseStateMachine.java
@@ -38,40 +38,77 @@ import org.slf4j.LoggerFactory;
  */
 public class ParseStateMachine {
 
+    /** The Constant LOG. */
     private static final Logger LOG = LoggerFactory.getLogger(ParseStateMachine.class);
 
+    /** The state. */
     private ParseState state = START_OF_LINE;
 
+    /** The token. */
     private StringBuilder token = new StringBuilder();
 
+    /** The characters read. */
     private int charactersRead;
 
+    /** The symbol mapping. */
     private SymbolMapping symbolMapping = new SymbolMapping();
 
+    /** The token state. */
     private TokenState tokenState = TokenState.RESET;
 
+    /** The trim. */
     private boolean trim = true;
 
+    /** The trash. */
     private boolean trash;
 
+    /** The current column. */
     private Column currentColumn = new Column();
 
+    /** The current line. */
     private int currentLine = 1;
 
+    /** The new line. */
     private int newLine = currentLine;
 
+    /**
+     * Gets the current line.
+     *
+     * @return the current line
+     */
     public int getCurrentLine() {
         return this.currentLine;
     }
 
+    /**
+     * Gets the current column.
+     *
+     * @return the current column
+     */
     public int getCurrentColumn() {
         return this.currentColumn.getColumnIndex();
     }
 
+    /**
+     * Checks if is trash.
+     *
+     * @return true, if is trash
+     */
     public boolean isTrash() {
         return this.trash;
     }
 
+    /**
+     * Offer symbol.
+     *
+     * @param symbolCharacter
+     *            the symbol character
+     *
+     * @return the string
+     *
+     * @throws ParseException
+     *             the parse exception
+     */
     public String offerSymbol(int symbolCharacter) throws ParseException {
 
         this.trash = false;
@@ -135,26 +172,64 @@ public class ParseStateMachine {
         return returnToken;
     }
 
+    /**
+     * Checks if is token start.
+     *
+     * @return true, if is token start
+     */
     public boolean isTokenStart() {
         return tokenState.isStart();
     }
 
+    /**
+     * Checks if is line finished.
+     *
+     * @return true, if is line finished
+     */
     public boolean isLineFinished() {
         return state.isLineFinished();
     }
 
+    /**
+     * Checks if is finished.
+     *
+     * @return true, if is finished
+     */
     public boolean isFinished() {
         return state == FINISHED;
     }
 
+    /**
+     * Ignore line.
+     *
+     * @return true, if successful
+     */
     public boolean ignoreLine() {
         return state.isIgnore() || isEmptyLine();
     }
 
+    /**
+     * Checks if is empty line.
+     *
+     * @return true, if is empty line
+     */
     public boolean isEmptyLine() {
         return charactersRead == 0;
     }
 
+    /**
+     * Determine state.
+     *
+     * @param symbolCharacter
+     *            the symbol character
+     * @param symbol
+     *            the symbol
+     *
+     * @return the parses the state
+     *
+     * @throws ParseException
+     *             the parse exception
+     */
     protected ParseState determineState(int symbolCharacter, EncounteredSymbol symbol) throws ParseException {
 
         switch (state) {
@@ -273,10 +348,21 @@ public class ParseStateMachine {
         }
     }
 
+    /**
+     * Sets the symbol mapping.
+     *
+     * @param symbolMapping
+     *            the new symbol mapping
+     */
     public void setSymbolMapping(SymbolMapping symbolMapping) {
         this.symbolMapping = symbolMapping;
     }
 
+    /**
+     * Gets the symbol mapping.
+     *
+     * @return the symbol mapping
+     */
     public SymbolMapping getSymbolMapping() {
         return this.symbolMapping;
     }

--- a/src/main/java/org/csveed/token/SymbolMapping.java
+++ b/src/main/java/org/csveed/token/SymbolMapping.java
@@ -25,21 +25,33 @@ import org.csveed.report.GeneralError;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * The Class SymbolMapping.
+ */
 public class SymbolMapping {
 
+    /** The Constant LOG. */
     private static final Logger LOG = LoggerFactory.getLogger(SymbolMapping.class);
 
+    /** The symbol to chars. */
     private Map<EncounteredSymbol, char[]> symbolToChars = new TreeMap<>();
+
+    /** The char to symbol. */
     private Map<Character, EncounteredSymbol> charToSymbol = new TreeMap<>();
 
+    /** The escape character. */
     private Character escapeCharacter;
 
+    /** The quote character. */
     private Character quoteCharacter;
 
+    /** The settings logged. */
     private boolean settingsLogged;
 
+    /** The start line. */
     private int startLine = 1;
 
+    /** The skip comment lines. */
     private boolean skipCommentLines = true;
 
     /**
@@ -49,10 +61,16 @@ public class SymbolMapping {
      */
     private char acceptedEndOfLine;
 
+    /**
+     * Instantiates a new symbol mapping.
+     */
     public SymbolMapping() {
         initDefaultMapping();
     }
 
+    /**
+     * Inits the default mapping.
+     */
     public void initDefaultMapping() {
         addMapping(EncounteredSymbol.ESCAPE_SYMBOL, '"');
         addMapping(EncounteredSymbol.QUOTE_SYMBOL, '"');
@@ -63,15 +81,39 @@ public class SymbolMapping {
         addMapping(EncounteredSymbol.COMMENT_SYMBOL, '#');
     }
 
+    /**
+     * Gets the first mapped character.
+     *
+     * @param encounteredSymbol
+     *            the encountered symbol
+     *
+     * @return the first mapped character
+     */
     public char getFirstMappedCharacter(EncounteredSymbol encounteredSymbol) {
         char[] mappedCharacters = getMappedCharacters(encounteredSymbol);
         return mappedCharacters == null ? 0 : mappedCharacters[0];
     }
 
+    /**
+     * Gets the mapped characters.
+     *
+     * @param encounteredSymbol
+     *            the encountered symbol
+     *
+     * @return the mapped characters
+     */
     public char[] getMappedCharacters(EncounteredSymbol encounteredSymbol) {
         return symbolToChars.get(encounteredSymbol);
     }
 
+    /**
+     * Adds the mapping.
+     *
+     * @param symbol
+     *            the symbol
+     * @param character
+     *            the character
+     */
     public void addMapping(EncounteredSymbol symbol, Character character) {
         addMapping(symbol, new char[] { character });
         if (symbol.isCheckForSimilarEscapeAndQuote()) {
@@ -79,6 +121,14 @@ public class SymbolMapping {
         }
     }
 
+    /**
+     * Adds the mapping.
+     *
+     * @param symbol
+     *            the symbol
+     * @param characters
+     *            the characters
+     */
     public void addMapping(EncounteredSymbol symbol, char[] characters) {
         while (charToSymbol.values().remove(symbol)) {
             // Looping until all symbols removed
@@ -89,6 +139,9 @@ public class SymbolMapping {
         symbolToChars.put(symbol, characters);
     }
 
+    /**
+     * Log settings.
+     */
     public void logSettings() {
         if (settingsLogged) {
             return;
@@ -104,6 +157,14 @@ public class SymbolMapping {
         settingsLogged = true;
     }
 
+    /**
+     * Characters to string.
+     *
+     * @param characters
+     *            the characters
+     *
+     * @return the string
+     */
     private String charactersToString(char[] characters) {
         StringBuilder returnString = new StringBuilder();
         for (char currentChar : characters) {
@@ -113,6 +174,14 @@ public class SymbolMapping {
         return returnString.toString();
     }
 
+    /**
+     * Char to printable.
+     *
+     * @param character
+     *            the character
+     *
+     * @return the string
+     */
     private String charToPrintable(char character) {
         switch (character) {
             case '\t':
@@ -126,6 +195,14 @@ public class SymbolMapping {
         }
     }
 
+    /**
+     * Store character for later comparison.
+     *
+     * @param symbol
+     *            the symbol
+     * @param character
+     *            the character
+     */
     private void storeCharacterForLaterComparison(EncounteredSymbol symbol, Character character) {
         if (symbol == ESCAPE_SYMBOL) {
             escapeCharacter = character;
@@ -134,10 +211,25 @@ public class SymbolMapping {
         }
     }
 
+    /**
+     * Checks if is same characters for escape and quote.
+     *
+     * @return true, if is same characters for escape and quote
+     */
     public boolean isSameCharactersForEscapeAndQuote() {
         return escapeCharacter != null && quoteCharacter != null && escapeCharacter.equals(quoteCharacter);
     }
 
+    /**
+     * Find.
+     *
+     * @param character
+     *            the character
+     * @param parseState
+     *            the parse state
+     *
+     * @return the encountered symbol
+     */
     public EncounteredSymbol find(int character, ParseState parseState) {
         if (character == -1) {
             return END_OF_FILE_SYMBOL;
@@ -161,10 +253,21 @@ public class SymbolMapping {
         return symbol;
     }
 
+    /**
+     * Gets the start line.
+     *
+     * @return the start line
+     */
     public int getStartLine() {
         return startLine;
     }
 
+    /**
+     * Sets the start line.
+     *
+     * @param startLine
+     *            the new start line
+     */
     public void setStartLine(int startLine) {
         if (startLine == 0) {
             throw new CsvException(new GeneralError("Row cannot be set at 0. Rows are 1-based"));
@@ -172,10 +275,21 @@ public class SymbolMapping {
         this.startLine = startLine;
     }
 
+    /**
+     * Checks if is skip comment lines.
+     *
+     * @return true, if is skip comment lines
+     */
     public boolean isSkipCommentLines() {
         return skipCommentLines;
     }
 
+    /**
+     * Sets the skip comment lines.
+     *
+     * @param skipCommentLines
+     *            the new skip comment lines
+     */
     public void setSkipCommentLines(boolean skipCommentLines) {
         this.skipCommentLines = skipCommentLines;
     }

--- a/src/main/java/org/csveed/token/TokenState.java
+++ b/src/main/java/org/csveed/token/TokenState.java
@@ -10,17 +10,43 @@
  */
 package org.csveed.token;
 
+/**
+ * The Enum TokenState.
+ */
 public enum TokenState {
-    RESET, START, PROCESSING;
 
+    /** The reset. */
+    RESET,
+
+    /** The start. */
+    START,
+
+    /** The processing. */
+    PROCESSING;
+
+    /**
+     * Next.
+     *
+     * @return the token state
+     */
     public TokenState next() {
         return values()[(ordinal() + 1) % 3];
     }
 
+    /**
+     * Checks if is start.
+     *
+     * @return true, if is start
+     */
     public boolean isStart() {
         return this == START;
     }
 
+    /**
+     * Checks if is reset.
+     *
+     * @return true, if is reset
+     */
     public boolean isReset() {
         return this == RESET;
     }


### PR DESCRIPTION
As noted previously this always seems contentious.  This is a baseline.  There are already multiple tickets open dating back to 2014 where javadocs are either missing or unclear.  We need a baseline then can fill out as we want from there.