### PR TITLE
[javadocs] Remove legacy author tag

### DIFF
--- a/src/main/java/org/csveed/annotations/CsvCell.java
+++ b/src/main/java/org/csveed/annotations/CsvCell.java
@@ -19,8 +19,6 @@ import java.lang.annotation.Target;
  * Various settings for a BeanInstructionsImpl translating to a CSV cell. By default every field in a
  * BeanInstructionsImpl is expected to be a CsvCell, even if not so marked. Use @CsvIgnore to prevent a
  * BeanInstructionsImpl field from being taken into account for both serialization and deserialization.
- *
- * @author Robert Bor
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/csveed/annotations/CsvConverter.java
+++ b/src/main/java/org/csveed/annotations/CsvConverter.java
@@ -19,8 +19,6 @@ import org.csveed.bean.conversion.Converter;
 
 /**
  * Sets a custom converter for the field. The converter must be of type Converter.
- *
- * @author Robert Bor
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/csveed/annotations/CsvDate.java
+++ b/src/main/java/org/csveed/annotations/CsvDate.java
@@ -18,8 +18,6 @@ import java.lang.annotation.Target;
 /**
  * Date is a special case, since it will require a format to be supplied. The format is similar to the one used in
  * SimpleDateFormat. As a matter of fact, this class is used under the hood to arrange the conversion.
- *
- * @author Robert Bor
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/csveed/annotations/CsvFile.java
+++ b/src/main/java/org/csveed/annotations/CsvFile.java
@@ -20,8 +20,6 @@ import org.csveed.bean.ColumnIndexMapper;
 
 /**
  * Various settings applying to the entire CSV file and BeanInstructions.
- *
- * @author Robert Bor
  */
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/csveed/annotations/CsvHeaderName.java
+++ b/src/main/java/org/csveed/annotations/CsvHeaderName.java
@@ -17,8 +17,6 @@ import java.lang.annotation.Target;
 
 /**
  * Determines whether the field will receive the header name of the current dynamic column.
- *
- * @author Robert Bor
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/csveed/annotations/CsvHeaderValue.java
+++ b/src/main/java/org/csveed/annotations/CsvHeaderValue.java
@@ -17,8 +17,6 @@ import java.lang.annotation.Target;
 
 /**
  * Determines whether the field will receive the cell value of the current dynamic column.
- *
- * @author Robert Bor
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/csveed/annotations/CsvIgnore.java
+++ b/src/main/java/org/csveed/annotations/CsvIgnore.java
@@ -18,8 +18,6 @@ import java.lang.annotation.Target;
 /**
  * When this annotation is set on a field, it will be skipped during deserialization even if a matching column name is
  * found. On serialization, it will not be part of the new CSV file.
- *
- * @author Robert Bor
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/csveed/annotations/CsvLocalizedNumber.java
+++ b/src/main/java/org/csveed/annotations/CsvLocalizedNumber.java
@@ -19,8 +19,6 @@ import java.lang.annotation.Target;
  * Makes sure that a specific Locale is used to convert numbers. If no Locale is required, no annotation needs to be
  * set, because the right converter will be picked up automatically. If you still wish to apply a custom converter, use
  * {@link CsvConverter}.
- *
- * @author Robert Bor
  */
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)

--- a/src/main/java/org/csveed/api/CsvClient.java
+++ b/src/main/java/org/csveed/api/CsvClient.java
@@ -31,8 +31,6 @@ import org.csveed.bean.conversion.Converter;
  * implementation with your own configuration settings</li>
  * </ul>
  *
- * @author Robert Bor
- *
  * @param <T>
  *            the bean class into which the rows are converted
  */

--- a/src/main/java/org/csveed/api/Header.java
+++ b/src/main/java/org/csveed/api/Header.java
@@ -14,8 +14,6 @@ import org.csveed.report.RowReport;
 
 /**
  * The original header of the CSV file.
- *
- * @author Robert Bor
  */
 public interface Header extends Iterable<String> {
 

--- a/src/main/java/org/csveed/api/Row.java
+++ b/src/main/java/org/csveed/api/Row.java
@@ -15,8 +15,6 @@ import org.csveed.report.RowReport;
 /**
  * A Row is a line of content read from the CSV file. Note that a Row is never a Header. Rows can be iterated which
  * yields the individual cells as Strings.
- *
- * @author Robert Bor
  */
 public interface Row extends Iterable<String> {
 

--- a/src/main/java/org/csveed/bean/BeanInstructions.java
+++ b/src/main/java/org/csveed/bean/BeanInstructions.java
@@ -20,8 +20,6 @@ import org.csveed.row.RowInstructions;
 /**
  * These instructions are used to power the {@link BeanReader}. Note that the instructions are also used internally if
  * annotations are used.
- *
- * @author Robert Bor
  */
 public interface BeanInstructions {
 

--- a/src/main/java/org/csveed/bean/BeanReader.java
+++ b/src/main/java/org/csveed/bean/BeanReader.java
@@ -26,8 +26,6 @@ import org.csveed.row.RowReader;
  * <li>Roll your own. Pass a {@link BeanInstructions} implementation with your own configuration settings</li>
  * </ul>
  *
- * @author Robert Bor
- *
  * @param <T>
  *            the bean class into which the rows are converted
  */

--- a/src/main/java/org/csveed/bean/DynamicColumn.java
+++ b/src/main/java/org/csveed/bean/DynamicColumn.java
@@ -49,8 +49,6 @@ import org.csveed.common.Column;
  * The header name and the cell value can be copied into bean properties. In the example, the bean requires two fields
  * date and visits. date must be annotated with @CsvHeaderName and visits with @CsvHeaderValue.
  * </p>
- *
- * @author Robert Bor
  */
 public class DynamicColumn {
 

--- a/src/main/java/org/csveed/bean/conversion/Converter.java
+++ b/src/main/java/org/csveed/bean/conversion/Converter.java
@@ -13,8 +13,6 @@ package org.csveed.bean.conversion;
 /**
  * Stateless converter from String to Object.
  *
- * @author Robert Bor
- *
  * @param <K>
  *            the Object to convert the String to
  */

--- a/src/main/java/org/csveed/report/CsvError.java
+++ b/src/main/java/org/csveed/report/CsvError.java
@@ -15,8 +15,6 @@ import java.util.List;
 /**
  * Report on an error, always including at the very least an error message. If the error can be pinpointed to a line or
  * cell, this information is included as well.
- *
- * @author Robert Bor
  */
 public interface CsvError {
 

--- a/src/main/java/org/csveed/row/RowInstructions.java
+++ b/src/main/java/org/csveed/row/RowInstructions.java
@@ -13,8 +13,6 @@ package org.csveed.row;
 /**
  * These instructions are used to power the {@link RowReader}. Note that the instructions are also used internally if
  * annotations are used.
- *
- * @author Robert Bor
  */
 public interface RowInstructions {
 

--- a/src/main/java/org/csveed/row/RowReader.java
+++ b/src/main/java/org/csveed/row/RowReader.java
@@ -17,8 +17,6 @@ import org.csveed.api.Row;
 
 /**
  * LineReaders reads rows from the CSV file and returns those all at once, or one by one if desired.
- *
- * @author Robert Bor
  */
 public interface RowReader {
 

--- a/src/main/java/org/csveed/row/RowReaderImpl.java
+++ b/src/main/java/org/csveed/row/RowReaderImpl.java
@@ -25,8 +25,6 @@ import org.csveed.token.ParseStateMachine;
 /**
  * Builds up a List of cells (String) per read row. Note that this class is stateful, so it can support a per-row parse
  * approach as well.
- *
- * @author Robert Bor
  */
 public class RowReaderImpl implements RowReader {
 

--- a/src/main/java/org/csveed/token/ParseStateMachine.java
+++ b/src/main/java/org/csveed/token/ParseStateMachine.java
@@ -33,8 +33,6 @@ import org.slf4j.LoggerFactory;
  * Yep, a state machine. Managing all kinds of booleans to form a pseudo-state doesn't work really well whereas a state
  * machine does. The state machine takes one character at a time, checks routes to the new state if necessary and holds
  * tokens, which it returns whenever a field-end ('popToken') has been found.
- *
- * @author Robert Bor
  */
 public class ParseStateMachine {
 


### PR DESCRIPTION
why?  causes users to blame the author when many touch it.  Modern coding, the git log is where we apply blame more directly to whom did something.  This lets us focus on the code.  Further, this was not applied everywhere to start with making it even less useful.