### PR TITLE
Use spdx license header for existing apache 2.0 license

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2025 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <extensions>

--- a/.mvn/settings.xml
+++ b/.mvn/settings.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2025 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <settings xmlns="http://maven.apache.org/SETTINGS/1.2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/LICENSE_HEADER
+++ b/LICENSE_HEADER
@@ -1,8 +1,4 @@
-CSVeed (https://github.com/42BV/CSVeed)
+SPDX-License-Identifier: Apache-2.0
+See LICENSE file for details.
 
-Copyright ${license.git.copyrightYears} CSVeed.
-
-All rights reserved. This program and the accompanying materials
-are made available under the terms of The Apache Software License,
-Version 2.0 which accompanies this distribution, and is available at
-https://www.apache.org/licenses/LICENSE-2.0.txt
+Copyright ${license.git.copyrightYears} 42 BV

--- a/format.xml
+++ b/format.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2023 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <!DOCTYPE Format>

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2026 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -37,8 +33,8 @@
 
     <licenses>
         <license>
-            <name>The Apache Software License, Version 2.0</name>
-            <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+            <name>Apache License, Version 2.0</name>
+            <url>https://www.apache.org/licenses/LICENSE-2.0.txt</url>
             <distribution>repo</distribution>
         </license>
     </licenses>

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     CSVeed (https://github.com/42BV/CSVeed)
 
-    Copyright 2013-2025 CSVeed.
+    Copyright 2013-2026 CSVeed.
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of The Apache Software License,

--- a/src/main/java/org/csveed/annotations/CsvCell.java
+++ b/src/main/java/org/csveed/annotations/CsvCell.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.annotations;
 

--- a/src/main/java/org/csveed/annotations/CsvConverter.java
+++ b/src/main/java/org/csveed/annotations/CsvConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.annotations;
 

--- a/src/main/java/org/csveed/annotations/CsvDate.java
+++ b/src/main/java/org/csveed/annotations/CsvDate.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.annotations;
 

--- a/src/main/java/org/csveed/annotations/CsvFile.java
+++ b/src/main/java/org/csveed/annotations/CsvFile.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.annotations;
 

--- a/src/main/java/org/csveed/annotations/CsvHeaderName.java
+++ b/src/main/java/org/csveed/annotations/CsvHeaderName.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.annotations;
 

--- a/src/main/java/org/csveed/annotations/CsvHeaderValue.java
+++ b/src/main/java/org/csveed/annotations/CsvHeaderValue.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.annotations;
 

--- a/src/main/java/org/csveed/annotations/CsvIgnore.java
+++ b/src/main/java/org/csveed/annotations/CsvIgnore.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.annotations;
 

--- a/src/main/java/org/csveed/annotations/CsvLocalizedNumber.java
+++ b/src/main/java/org/csveed/annotations/CsvLocalizedNumber.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.annotations;
 

--- a/src/main/java/org/csveed/annotations/package-info.java
+++ b/src/main/java/org/csveed/annotations/package-info.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 /**
  * <p>

--- a/src/main/java/org/csveed/api/CsvClient.java
+++ b/src/main/java/org/csveed/api/CsvClient.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.api;
 

--- a/src/main/java/org/csveed/api/CsvClientImpl.java
+++ b/src/main/java/org/csveed/api/CsvClientImpl.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.api;
 

--- a/src/main/java/org/csveed/api/Header.java
+++ b/src/main/java/org/csveed/api/Header.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.api;
 

--- a/src/main/java/org/csveed/api/Row.java
+++ b/src/main/java/org/csveed/api/Row.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.api;
 

--- a/src/main/java/org/csveed/api/package-info.java
+++ b/src/main/java/org/csveed/api/package-info.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 /**
  * The main interface of interaction with CSVeed for a developer. The most important interface here is

--- a/src/main/java/org/csveed/bean/AbstractMapper.java
+++ b/src/main/java/org/csveed/bean/AbstractMapper.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/BeanInstructions.java
+++ b/src/main/java/org/csveed/bean/BeanInstructions.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/BeanInstructionsImpl.java
+++ b/src/main/java/org/csveed/bean/BeanInstructionsImpl.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/BeanParser.java
+++ b/src/main/java/org/csveed/bean/BeanParser.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/BeanProperties.java
+++ b/src/main/java/org/csveed/bean/BeanProperties.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/BeanProperty.java
+++ b/src/main/java/org/csveed/bean/BeanProperty.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/BeanReader.java
+++ b/src/main/java/org/csveed/bean/BeanReader.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/BeanReaderImpl.java
+++ b/src/main/java/org/csveed/bean/BeanReaderImpl.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/BeanWriter.java
+++ b/src/main/java/org/csveed/bean/BeanWriter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/BeanWriterImpl.java
+++ b/src/main/java/org/csveed/bean/BeanWriterImpl.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/ColumnIndexMapper.java
+++ b/src/main/java/org/csveed/bean/ColumnIndexMapper.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/ColumnNameMapper.java
+++ b/src/main/java/org/csveed/bean/ColumnNameMapper.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/DynamicColumn.java
+++ b/src/main/java/org/csveed/bean/DynamicColumn.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/main/java/org/csveed/bean/conversion/AbstractConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/AbstractConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/BeanPropertyConversionException.java
+++ b/src/main/java/org/csveed/bean/conversion/BeanPropertyConversionException.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/BeanWrapper.java
+++ b/src/main/java/org/csveed/bean/conversion/BeanWrapper.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/ByteArrayConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/ByteArrayConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/CharArrayConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/CharArrayConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/CharacterConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/CharacterConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/CharsetConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/CharsetConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/ConversionException.java
+++ b/src/main/java/org/csveed/bean/conversion/ConversionException.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/ConversionUtil.java
+++ b/src/main/java/org/csveed/bean/conversion/ConversionUtil.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/Converter.java
+++ b/src/main/java/org/csveed/bean/conversion/Converter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/CurrencyConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/CurrencyConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/CustomBooleanConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/CustomBooleanConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/CustomNumberConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/CustomNumberConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/DateConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/DateConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/DefaultConverters.java
+++ b/src/main/java/org/csveed/bean/conversion/DefaultConverters.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/EasyAbstractConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/EasyAbstractConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/EnumConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/EnumConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/NoConverterFoundException.java
+++ b/src/main/java/org/csveed/bean/conversion/NoConverterFoundException.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/NumberUtils.java
+++ b/src/main/java/org/csveed/bean/conversion/NumberUtils.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/PatternConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/PatternConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/StringConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/StringConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/TimeZoneConverter.java
+++ b/src/main/java/org/csveed/bean/conversion/TimeZoneConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/main/java/org/csveed/bean/conversion/package-info.java
+++ b/src/main/java/org/csveed/bean/conversion/package-info.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 /**
  * <p>

--- a/src/main/java/org/csveed/bean/package-info.java
+++ b/src/main/java/org/csveed/bean/package-info.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 /**
  * The package responsible for converting Rows to Beans. In here are the classes needed for reading class structures,

--- a/src/main/java/org/csveed/common/Column.java
+++ b/src/main/java/org/csveed/common/Column.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.common;
 

--- a/src/main/java/org/csveed/common/ColumnExcel.java
+++ b/src/main/java/org/csveed/common/ColumnExcel.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.common;
 

--- a/src/main/java/org/csveed/common/ColumnIndexKey.java
+++ b/src/main/java/org/csveed/common/ColumnIndexKey.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.common;
 

--- a/src/main/java/org/csveed/common/ColumnKey.java
+++ b/src/main/java/org/csveed/common/ColumnKey.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.common;
 

--- a/src/main/java/org/csveed/common/ColumnNameKey.java
+++ b/src/main/java/org/csveed/common/ColumnNameKey.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.common;
 

--- a/src/main/java/org/csveed/common/package-info.java
+++ b/src/main/java/org/csveed/common/package-info.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2024 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 /**
  * Contains common code for csveed.

--- a/src/main/java/org/csveed/report/AbstractCsvError.java
+++ b/src/main/java/org/csveed/report/AbstractCsvError.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.report;
 

--- a/src/main/java/org/csveed/report/CsvError.java
+++ b/src/main/java/org/csveed/report/CsvError.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.report;
 

--- a/src/main/java/org/csveed/report/CsvException.java
+++ b/src/main/java/org/csveed/report/CsvException.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.report;
 

--- a/src/main/java/org/csveed/report/GeneralError.java
+++ b/src/main/java/org/csveed/report/GeneralError.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.report;
 

--- a/src/main/java/org/csveed/report/RowError.java
+++ b/src/main/java/org/csveed/report/RowError.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.report;
 

--- a/src/main/java/org/csveed/report/RowPart.java
+++ b/src/main/java/org/csveed/report/RowPart.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.report;
 

--- a/src/main/java/org/csveed/report/RowReport.java
+++ b/src/main/java/org/csveed/report/RowReport.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.report;
 

--- a/src/main/java/org/csveed/report/package-info.java
+++ b/src/main/java/org/csveed/report/package-info.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 /**
  * Contains all the classes required to report back on a row. This can be either when an error occured internally, or it

--- a/src/main/java/org/csveed/row/CellPositionInRow.java
+++ b/src/main/java/org/csveed/row/CellPositionInRow.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/main/java/org/csveed/row/HeaderImpl.java
+++ b/src/main/java/org/csveed/row/HeaderImpl.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/main/java/org/csveed/row/Line.java
+++ b/src/main/java/org/csveed/row/Line.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/main/java/org/csveed/row/LineWithInfo.java
+++ b/src/main/java/org/csveed/row/LineWithInfo.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/main/java/org/csveed/row/RowImpl.java
+++ b/src/main/java/org/csveed/row/RowImpl.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/main/java/org/csveed/row/RowInstructions.java
+++ b/src/main/java/org/csveed/row/RowInstructions.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/main/java/org/csveed/row/RowInstructionsImpl.java
+++ b/src/main/java/org/csveed/row/RowInstructionsImpl.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/main/java/org/csveed/row/RowReader.java
+++ b/src/main/java/org/csveed/row/RowReader.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/main/java/org/csveed/row/RowReaderImpl.java
+++ b/src/main/java/org/csveed/row/RowReaderImpl.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/main/java/org/csveed/row/RowWriter.java
+++ b/src/main/java/org/csveed/row/RowWriter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/main/java/org/csveed/row/RowWriterImpl.java
+++ b/src/main/java/org/csveed/row/RowWriterImpl.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/main/java/org/csveed/row/package-info.java
+++ b/src/main/java/org/csveed/row/package-info.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 /**
  * The package responsible for converting a group of tokens into Header and Rows. In here you will find ways to read

--- a/src/main/java/org/csveed/test/annotations/Placeholder.java
+++ b/src/main/java/org/csveed/test/annotations/Placeholder.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2024 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.annotations;
 

--- a/src/main/java/org/csveed/test/annotations/package-info.java
+++ b/src/main/java/org/csveed/test/annotations/package-info.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2024 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 /**
  * Placeholder to resolve javadoc requirements.

--- a/src/main/java/org/csveed/test/converters/Placeholder.java
+++ b/src/main/java/org/csveed/test/converters/Placeholder.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2024 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.converters;
 

--- a/src/main/java/org/csveed/test/converters/package-info.java
+++ b/src/main/java/org/csveed/test/converters/package-info.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2024 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 /**
  * Placeholder to resolve javadoc requirements.

--- a/src/main/java/org/csveed/test/model/Placeholder.java
+++ b/src/main/java/org/csveed/test/model/Placeholder.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2024 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/main/java/org/csveed/test/model/package-info.java
+++ b/src/main/java/org/csveed/test/model/package-info.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2024 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 /**
  * Placeholder to resolve javadoc requirements.

--- a/src/main/java/org/csveed/token/EncounteredSymbol.java
+++ b/src/main/java/org/csveed/token/EncounteredSymbol.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.token;
 

--- a/src/main/java/org/csveed/token/ParseException.java
+++ b/src/main/java/org/csveed/token/ParseException.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.token;
 

--- a/src/main/java/org/csveed/token/ParseState.java
+++ b/src/main/java/org/csveed/token/ParseState.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.token;
 

--- a/src/main/java/org/csveed/token/ParseStateMachine.java
+++ b/src/main/java/org/csveed/token/ParseStateMachine.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.token;
 

--- a/src/main/java/org/csveed/token/SymbolMapping.java
+++ b/src/main/java/org/csveed/token/SymbolMapping.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.token;
 

--- a/src/main/java/org/csveed/token/TokenState.java
+++ b/src/main/java/org/csveed/token/TokenState.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.token;
 

--- a/src/main/java/org/csveed/token/package-info.java
+++ b/src/main/java/org/csveed/token/package-info.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 /**
  * The package responsible for reading a CSV line from a {@link java.io.Reader} and converting this to tokens. The

--- a/src/site/resources/annotations.html
+++ b/src/site/resources/annotations.html
@@ -1,13 +1,9 @@
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2023 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <!DOCTYPE html>

--- a/src/site/resources/architecture.html
+++ b/src/site/resources/architecture.html
@@ -1,13 +1,9 @@
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2023 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <!DOCTYPE html>

--- a/src/site/resources/comparison-matrix.html
+++ b/src/site/resources/comparison-matrix.html
@@ -1,13 +1,9 @@
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2023 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <!DOCTYPE html>

--- a/src/site/resources/comparison.html
+++ b/src/site/resources/comparison.html
@@ -1,13 +1,9 @@
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2023 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <!DOCTYPE html>

--- a/src/site/resources/csveed.html
+++ b/src/site/resources/csveed.html
@@ -1,13 +1,9 @@
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2023 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <!DOCTYPE html>

--- a/src/site/resources/design-choices.html
+++ b/src/site/resources/design-choices.html
@@ -1,13 +1,9 @@
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2023 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <!DOCTYPE html>

--- a/src/site/resources/javascripts/main.js
+++ b/src/site/resources/javascripts/main.js
@@ -1,11 +1,7 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 console.log('This would be the main JS file.');

--- a/src/site/resources/release-notes.html
+++ b/src/site/resources/release-notes.html
@@ -1,13 +1,9 @@
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2023 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <!DOCTYPE html>

--- a/src/site/resources/rfc4180.html
+++ b/src/site/resources/rfc4180.html
@@ -1,13 +1,9 @@
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2023 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <!DOCTYPE html>

--- a/src/site/resources/stylesheets/csveed.css
+++ b/src/site/resources/stylesheets/csveed.css
@@ -1,12 +1,8 @@
 /**
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 .csveed-logo {
     width: 160px;

--- a/src/site/resources/stylesheets/print.css
+++ b/src/site/resources/stylesheets/print.css
@@ -1,12 +1,8 @@
 /**
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 html, body, div, span, applet, object, iframe,
 h1, h2, h3, h4, h5, h6, p, blockquote, pre,

--- a/src/site/resources/stylesheets/pygment_trac.css
+++ b/src/site/resources/stylesheets/pygment_trac.css
@@ -1,12 +1,8 @@
 /**
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 .highlight  { background: #ffffff; }
 .highlight .c { color: #999988; font-style: italic } /* Comment */

--- a/src/site/resources/stylesheets/stylesheet.css
+++ b/src/site/resources/stylesheets/stylesheet.css
@@ -1,12 +1,8 @@
 /**
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 /* http://meyerweb.com/eric/tools/css/reset/
    v2.0 | 20110126

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -1,14 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    CSVeed (https://github.com/42BV/CSVeed)
+    SPDX-License-Identifier: Apache-2.0
+    See LICENSE file for details.
 
-    Copyright 2013-2025 CSVeed.
-
-    All rights reserved. This program and the accompanying materials
-    are made available under the terms of The Apache Software License,
-    Version 2.0 which accompanies this distribution, and is available at
-    https://www.apache.org/licenses/LICENSE-2.0.txt
+    Copyright 2013-2026 42 BV
 
 -->
 <site name="${project.name}" xmlns="http://maven.apache.org/SITE/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/src/test/java/org/csveed/api/CsvClientTest.java
+++ b/src/test/java/org/csveed/api/CsvClientTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.api;
 

--- a/src/test/java/org/csveed/bean/BeanInstructionsImplTest.java
+++ b/src/test/java/org/csveed/bean/BeanInstructionsImplTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/test/java/org/csveed/bean/BeanParserTest.java
+++ b/src/test/java/org/csveed/bean/BeanParserTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/test/java/org/csveed/bean/BeanPropertiesTest.java
+++ b/src/test/java/org/csveed/bean/BeanPropertiesTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/test/java/org/csveed/bean/BeanPropertyTest.java
+++ b/src/test/java/org/csveed/bean/BeanPropertyTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/test/java/org/csveed/bean/BeanReaderTest.java
+++ b/src/test/java/org/csveed/bean/BeanReaderTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/test/java/org/csveed/bean/BeanWriterTest.java
+++ b/src/test/java/org/csveed/bean/BeanWriterTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/test/java/org/csveed/bean/DynamicColumnTest.java
+++ b/src/test/java/org/csveed/bean/DynamicColumnTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean;
 

--- a/src/test/java/org/csveed/bean/conversion/Bean.java
+++ b/src/test/java/org/csveed/bean/conversion/Bean.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/test/java/org/csveed/bean/conversion/BeanWrapperTest.java
+++ b/src/test/java/org/csveed/bean/conversion/BeanWrapperTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/test/java/org/csveed/bean/conversion/Coordinate.java
+++ b/src/test/java/org/csveed/bean/conversion/Coordinate.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/test/java/org/csveed/bean/conversion/EasyAbstractConverterTest.java
+++ b/src/test/java/org/csveed/bean/conversion/EasyAbstractConverterTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/test/java/org/csveed/bean/conversion/EnumConverterTest.java
+++ b/src/test/java/org/csveed/bean/conversion/EnumConverterTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.bean.conversion;
 

--- a/src/test/java/org/csveed/common/ColumnKeyTest.java
+++ b/src/test/java/org/csveed/common/ColumnKeyTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.common;
 

--- a/src/test/java/org/csveed/common/ColumnTest.java
+++ b/src/test/java/org/csveed/common/ColumnTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.common;
 

--- a/src/test/java/org/csveed/report/RowReportTest.java
+++ b/src/test/java/org/csveed/report/RowReportTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.report;
 

--- a/src/test/java/org/csveed/row/HeaderTest.java
+++ b/src/test/java/org/csveed/row/HeaderTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/test/java/org/csveed/row/LineWithInfoTest.java
+++ b/src/test/java/org/csveed/row/LineWithInfoTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/test/java/org/csveed/row/RowReaderTest.java
+++ b/src/test/java/org/csveed/row/RowReaderTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/test/java/org/csveed/row/RowWriterTest.java
+++ b/src/test/java/org/csveed/row/RowWriterTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.row;
 

--- a/src/test/java/org/csveed/test/annotations/IgnoreClass.java
+++ b/src/test/java/org/csveed/test/annotations/IgnoreClass.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.annotations;
 

--- a/src/test/java/org/csveed/test/annotations/IgnoreField.java
+++ b/src/test/java/org/csveed/test/annotations/IgnoreField.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.annotations;
 

--- a/src/test/java/org/csveed/test/converters/BeanSimpleConverter.java
+++ b/src/test/java/org/csveed/test/converters/BeanSimpleConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.converters;
 

--- a/src/test/java/org/csveed/test/model/BeanCommodity.java
+++ b/src/test/java/org/csveed/test/model/BeanCommodity.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanCustomComments.java
+++ b/src/test/java/org/csveed/test/model/BeanCustomComments.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanLotsOfIgnores.java
+++ b/src/test/java/org/csveed/test/model/BeanLotsOfIgnores.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanSimple.java
+++ b/src/test/java/org/csveed/test/model/BeanSimple.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanVariousNotAnnotated.java
+++ b/src/test/java/org/csveed/test/model/BeanVariousNotAnnotated.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithAlienSettings.java
+++ b/src/test/java/org/csveed/test/model/BeanWithAlienSettings.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithConverter.java
+++ b/src/test/java/org/csveed/test/model/BeanWithConverter.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithCustomIndexes.java
+++ b/src/test/java/org/csveed/test/model/BeanWithCustomIndexes.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithCustomNumber.java
+++ b/src/test/java/org/csveed/test/model/BeanWithCustomNumber.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithCustomNumberAnnotated.java
+++ b/src/test/java/org/csveed/test/model/BeanWithCustomNumberAnnotated.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithEnum.java
+++ b/src/test/java/org/csveed/test/model/BeanWithEnum.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithEnumAndMore.java
+++ b/src/test/java/org/csveed/test/model/BeanWithEnumAndMore.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithMultipleStrings.java
+++ b/src/test/java/org/csveed/test/model/BeanWithMultipleStrings.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithNameMatching.java
+++ b/src/test/java/org/csveed/test/model/BeanWithNameMatching.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithNonStandardObject.java
+++ b/src/test/java/org/csveed/test/model/BeanWithNonStandardObject.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithVariousTypes.java
+++ b/src/test/java/org/csveed/test/model/BeanWithVariousTypes.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithWrongAnnotation.java
+++ b/src/test/java/org/csveed/test/model/BeanWithWrongAnnotation.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithoutGettersAndSetters.java
+++ b/src/test/java/org/csveed/test/model/BeanWithoutGettersAndSetters.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithoutHeader.java
+++ b/src/test/java/org/csveed/test/model/BeanWithoutHeader.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/test/model/BeanWithoutNoArgPublicConstructor.java
+++ b/src/test/java/org/csveed/test/model/BeanWithoutNoArgPublicConstructor.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.test.model;
 

--- a/src/test/java/org/csveed/token/ParseStateMachineTest.java
+++ b/src/test/java/org/csveed/token/ParseStateMachineTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.token;
 

--- a/src/test/java/org/csveed/token/SymbolMappingTest.java
+++ b/src/test/java/org/csveed/token/SymbolMappingTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.token;
 

--- a/src/test/java/org/csveed/token/TokenStateTest.java
+++ b/src/test/java/org/csveed/token/TokenStateTest.java
@@ -1,12 +1,8 @@
 /*
- * CSVeed (https://github.com/42BV/CSVeed)
+ * SPDX-License-Identifier: Apache-2.0
+ * See LICENSE file for details.
  *
- * Copyright 2013-2023 CSVeed.
- *
- * All rights reserved. This program and the accompanying materials
- * are made available under the terms of The Apache Software License,
- * Version 2.0 which accompanies this distribution, and is available at
- * https://www.apache.org/licenses/LICENSE-2.0.txt
+ * Copyright 2013-2026 42 BV
  */
 package org.csveed.token;
 

--- a/src/test/resources/simplelogger.properties
+++ b/src/test/resources/simplelogger.properties
@@ -1,12 +1,8 @@
 #
-# CSVeed (https://github.com/42BV/CSVeed)
+# SPDX-License-Identifier: Apache-2.0
+# See LICENSE file for details.
 #
-# Copyright 2013-2023 CSVeed.
-#
-# All rights reserved. This program and the accompanying materials
-# are made available under the terms of The Apache Software License,
-# Version 2.0 which accompanies this distribution, and is available at
-# https://www.apache.org/licenses/LICENSE-2.0.txt
+# Copyright 2013-2026 42 BV
 #
 
 org.slf4j.simpleLogger.logFile=target/logging.output


### PR DESCRIPTION
this makes for easier modernized detection needs.